### PR TITLE
fix(release): unblock snap publish + stop release.yml double-building snap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,12 @@ jobs:
       - name: Build
         run: pnpm build
       - name: Package
-        run: pnpm exec electron-builder --linux --config build/electron-builder.yml --publish always
+        # Only AppImage + deb here. Snap is owned by snap-publish.yml
+        # (separate job, separate credentials). Without an explicit list,
+        # electron-builder reads the linux.target array in the YAML —
+        # which includes snap — and tries to publish a snap to the Snap
+        # Store from this job, which doesn't have the credentials.
+        run: pnpm exec electron-builder --linux AppImage deb --config build/electron-builder.yml --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/snap-publish.yml
+++ b/.github/workflows/snap-publish.yml
@@ -61,7 +61,12 @@ jobs:
           # electron-builder's snap target invokes snapcraft under the hood; in
           # CI we want destructive-mode (no LXD container).
           SNAPCRAFT_BUILD_ENVIRONMENT: 'host'
-        run: pnpm exec electron-builder --linux snap --config build/electron-builder.yml
+        # --publish never: electron-builder otherwise tries to push to the
+        # Snap Store during build when it sees a git tag, but
+        # SNAPCRAFT_STORE_CREDENTIALS is only available in the publish-*
+        # jobs below. Disable implicit publish; the dedicated job uses
+        # snapcore/action-publish with the credentials properly scoped.
+        run: pnpm exec electron-builder --linux snap --config build/electron-builder.yml --publish never
 
       - name: Locate snap file
         id: find


### PR DESCRIPTION
v0.2.0's first run revealed two release-pipeline issues:

1. **snap-publish.yml** failed at the build step because electron-builder, on detecting a git tag, tried to publish to the Snap Store from inside the build job — which doesn't have SNAPCRAFT_STORE_CREDENTIALS (those are scoped to the publish-edge / publish-stable jobs). Adds \`--publish never\` to the build invocation; the dedicated publish jobs use \`snapcore/action-publish\` with credentials properly scoped.

2. **release.yml**'s release-linux job was building all three linux targets (AppImage, deb, snap) and hit the same implicit-publish trap on the snap step. Constrains it to \`--linux AppImage deb\`; snap is exclusively owned by snap-publish.yml.

The v0.2.0 tag's AppImage / .deb / Windows artefacts shipped successfully despite the workflow showing failure. Snap publish needs a re-trigger after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)