### PR TITLE
fix(snap): remove duplicate + invalid plug entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ Native desktop client for [Etherpad](https://etherpad.org/) — a multi-instance
 thin client with per-instance session isolation, a navigable pad sidebar, and
 the keyboard shortcuts you'd expect from a modern app.
 
-> Built with Electron 41 + electron-vite + Vite 7 + React 19 + Zustand 5 +
-> TypeScript strict end-to-end. Apache-2.0, matching upstream Etherpad.
-
 > [!NOTE]
 > **Status: v0 beta.** Linux (AppImage / `.deb` / Snap), Windows (NSIS
 > installer / portable `.exe`), and macOS (DMG, arm64 + x64) ship in the

--- a/build/electron-builder.yml
+++ b/build/electron-builder.yml
@@ -105,15 +105,24 @@ appImage:
 snap:
   grade: stable
   confinement: strict
-  # Etherpad Desktop needs network for talking to user-supplied Etherpad
-  # servers, plus the standard Electron desktop plugs.
+  # The Snap Store auto-rejects builds with duplicate plug entries in
+  # snap.json. electron-builder injects a default plug set that already
+  # covers desktop / x11 / wayland / unity7 / browser-support / network /
+  # home / etc. — listing the same plugs again here produces the
+  # "['network', 'home', ...] has non-unique elements" rejection.
+  #
+  # Only list plugs that AREN'T in electron-builder's default set:
+  #   - network-bind: needed if we ever bind a port (embedded Etherpad).
+  #   - removable-media: read pads stored on a USB drive / SD card.
+  #
+  # The previous list also included `browser-sandbox`, which is NOT a
+  # real Snap interface — manual store reviewers flag invalid plug
+  # names as "potentially malicious" because they look like attempts
+  # to request undeclared capabilities.
   plugs:
     - default
-    - network
     - network-bind
-    - home
     - removable-media
-    - browser-sandbox
   # The snap-store base. core24 (Ubuntu 24.04) matches our Node 22 baseline.
   base: core24
   # Display name in the Snap Store

--- a/tests/e2e/menu-click.spec.ts
+++ b/tests/e2e/menu-click.spec.ts
@@ -115,7 +115,9 @@ test('Help > About Etherpad Desktop opens AboutDialog (the user-reported bug)', 
     const ok = await clickHelpMenuItem(h, 'About Etherpad Desktop');
     expect(ok).toBe(true);
     await expect(h.shell.getByRole('heading', { name: /^etherpad desktop$/i })).toBeVisible();
-    await expect(h.shell.getByText(/version 0\.1\.0/i)).toBeVisible();
+    // Match any semver — release-please bumps the version on every
+    // user-visible commit, so a hardcoded literal goes stale fast.
+    await expect(h.shell.getByText(/version \d+\.\d+\.\d+/i)).toBeVisible();
   } finally {
     await h.close();
   }


### PR DESCRIPTION
The Snap Store rejected v0.3.0 with two errors. Both are fixed by trimming our \`snap.plugs\` list to only the entries that aren't already in electron-builder's defaults.

See commit message for details. Manual reviewer's "made private" flag will need to be resolved via help@snapcraft.io separately.