### PR TITLE
feat(mobile): real persistence via @capacitor/preferences (Phase 4)

### DIFF
--- a/docs/superpowers/plans/2026-05-11-etherpad-mobile-phase4-storage.md
+++ b/docs/superpowers/plans/2026-05-11-etherpad-mobile-phase4-storage.md
@@ -1,0 +1,472 @@
+# Phase 4 — Mobile storage + state Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `CapacitorPlatform`'s stub reads + rejecting writes with real persistence via `@capacitor/preferences`. After this PR, the workspace/padHistory/settings model survives across reloads (and across app launches once on a real device). The shell renders persisted workspaces on hydrate; adding/removing workspaces and changing settings round-trips correctly.
+
+**Architecture:** Three small per-concern stores (`workspace-store`, `pad-history-store`, `settings-store`) wrap `@capacitor/preferences` reads/writes with Zod validation. Schemas reuse the existing definitions from `@etherpad/shell/validation/*` — no schema duplication. Each persisted blob carries `schemaVersion: 1`. The Capacitor Preferences web fallback stores values in `localStorage` under the `CapacitorStorage.<key>` prefix, so the same code runs in `vite dev` / `preview` and inside the Android WebView.
+
+**Tech Stack:** `@capacitor/preferences` 8.x, Zod (via shell), TypeScript strict.
+
+---
+
+## Decisions locked in
+
+1. **Reuse shell's Zod schemas verbatim.** No mobile-specific validators.
+2. **One Preferences key per concern**: `etherpad:workspaces` (workspaces+order), `etherpad:settings`, `etherpad:padHistory:<workspaceId>`. Per-workspace pad history keys keep large blobs out of the workspace doc.
+3. **No `@capacitor/filesystem` in this phase.** Pad history is currently small (per-workspace lists, not pad bodies); Preferences with 6MB+ headroom is fine. Filesystem comes when pad content indexing lands in Phase 5+.
+4. **Tab/window/httpLogin/updater/quickSwitcher stay stubbed.** Phase 5 wires pad rendering; tab state is meaningless until then. httpLogin is desktop-only. Updater is desktop-only. quickSwitcher needs pad content indexing (later phase).
+5. **Smoke test path:** pre-seed `localStorage` via `page.addInitScript`, reload, assert workspace renders in the rail. This tests the *read* path end-to-end (the more risky path — it has to thread persisted JSON through Zod into the shell store). Write path is tested by writing-then-reading in the same test.
+
+---
+
+## File structure after this plan
+
+```
+packages/mobile/src/platform/
+├── capacitor.ts                   # createCapacitorPlatform() — refactored to use stores
+└── storage/
+    ├── preferences.ts             # tiny wrapper over @capacitor/preferences w/ Zod validation
+    ├── workspace-store.ts         # load/save {workspaces, order}
+    ├── pad-history-store.ts       # per-workspace pad history
+    └── settings-store.ts          # load/save Settings
+```
+
+---
+
+## Task 1: Add `@capacitor/preferences` dependency
+
+- [ ] **Step 1: Add dep**
+
+```bash
+pnpm --filter @etherpad/mobile add @capacitor/preferences@^8.0.0
+pnpm install
+```
+
+- [ ] **Step 2: Update `packages/mobile/capacitor.config.ts` if needed**
+
+`@capacitor/preferences` requires no native install on Android (it's first-party). `cap sync` will register it automatically once we commit and run.
+
+```bash
+pnpm --filter @etherpad/mobile exec cap sync android 2>&1 | tail -10
+```
+
+(In CI we don't run cap sync; in local dev we do.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "chore(mobile): add @capacitor/preferences dependency"
+git push -u origin feat/mobile-phase4-storage
+```
+
+---
+
+## Task 2: Build the Preferences wrapper
+
+- [ ] **Step 1: Create `packages/mobile/src/platform/storage/preferences.ts`**
+
+```typescript
+import { Preferences } from '@capacitor/preferences';
+import type { ZodTypeAny, infer as zInfer } from 'zod';
+
+/**
+ * Read a Preferences key and parse it with the given Zod schema. Returns
+ * `null` when the key is absent or the stored JSON doesn't match the
+ * schema (caller's responsibility to fall back to a default in that case).
+ *
+ * The "couldn't parse" branch is treated as "no value" rather than thrown
+ * because Phase 4 is single-runtime — if data on disk doesn't validate,
+ * we'd rather reset to default than crash the app on boot.
+ */
+export async function loadJson<S extends ZodTypeAny>(
+  key: string,
+  schema: S,
+): Promise<zInfer<S> | null> {
+  const { value } = await Preferences.get({ key });
+  if (value === null) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    const result = schema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveJson<S extends ZodTypeAny>(
+  key: string,
+  schema: S,
+  value: zInfer<S>,
+): Promise<void> {
+  // Validate before persisting so we never write a malformed blob.
+  schema.parse(value);
+  await Preferences.set({ key, value: JSON.stringify(value) });
+}
+
+export async function removeKey(key: string): Promise<void> {
+  await Preferences.remove({ key });
+}
+
+export async function listKeys(): Promise<string[]> {
+  const { keys } = await Preferences.keys();
+  return keys;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/mobile/src/platform/storage/preferences.ts
+git commit -m "feat(mobile): add Preferences wrapper with Zod validation"
+git push
+```
+
+---
+
+## Task 3: Workspace store
+
+- [ ] **Step 1: Create `packages/mobile/src/platform/storage/workspace-store.ts`**
+
+```typescript
+import type { Workspace } from '@etherpad/shell/state';   // adjust if export path differs
+import { workspacesFileSchema } from '@shared/validation/workspace';
+import { loadJson, saveJson } from './preferences.js';
+
+const KEY = 'etherpad:workspaces';
+
+export interface WorkspacesFile {
+  schemaVersion: 1;
+  workspaces: Workspace[];
+  order: string[];
+}
+
+async function load(): Promise<WorkspacesFile> {
+  const file = await loadJson(KEY, workspacesFileSchema);
+  return file ?? { schemaVersion: 1, workspaces: [], order: [] };
+}
+
+async function save(file: WorkspacesFile): Promise<void> {
+  await saveJson(KEY, workspacesFileSchema, file);
+}
+
+export async function list(): Promise<{ workspaces: Workspace[]; order: string[] }> {
+  const file = await load();
+  return { workspaces: file.workspaces, order: file.order };
+}
+
+export async function add(
+  input: { name: string; serverUrl?: string; color: string; kind?: 'remote' | 'embedded' },
+): Promise<Workspace> {
+  const file = await load();
+  const ws: Workspace = {
+    id: crypto.randomUUID(),
+    name: input.name,
+    serverUrl: input.serverUrl ?? '',
+    color: input.color,
+    createdAt: Date.now(),
+    ...(input.kind ? { kind: input.kind } : {}),
+  };
+  file.workspaces.push(ws);
+  file.order.push(ws.id);
+  await save(file);
+  return ws;
+}
+
+export async function update(
+  input: { id: string; name?: string; serverUrl?: string; color?: string },
+): Promise<Workspace> {
+  const file = await load();
+  const ws = file.workspaces.find((w) => w.id === input.id);
+  if (!ws) throw new Error(`Workspace ${input.id} not found`);
+  if (input.name !== undefined) ws.name = input.name;
+  if (input.serverUrl !== undefined) ws.serverUrl = input.serverUrl;
+  if (input.color !== undefined) ws.color = input.color;
+  await save(file);
+  return ws;
+}
+
+export async function remove(input: { id: string }): Promise<void> {
+  const file = await load();
+  file.workspaces = file.workspaces.filter((w) => w.id !== input.id);
+  file.order = file.order.filter((id) => id !== input.id);
+  await save(file);
+}
+
+export async function reorder(input: { order: string[] }): Promise<string[]> {
+  const file = await load();
+  // Validate every id exists.
+  const known = new Set(file.workspaces.map((w) => w.id));
+  for (const id of input.order) {
+    if (!known.has(id)) throw new Error(`Unknown workspace ${id}`);
+  }
+  file.order = input.order;
+  await save(file);
+  return input.order;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/mobile/src/platform/storage/workspace-store.ts
+git commit -m "feat(mobile): add workspace store backed by Preferences"
+git push
+```
+
+---
+
+## Task 4: Pad history store
+
+- [ ] **Step 1: Create `packages/mobile/src/platform/storage/pad-history-store.ts`**
+
+```typescript
+import type { PadHistoryEntry } from '@shared/types/pad-history';
+import { padHistoryFileSchema } from '@shared/validation/pad-history';
+import { listKeys, loadJson, removeKey, saveJson } from './preferences.js';
+
+const PREFIX = 'etherpad:padHistory:';
+const keyFor = (workspaceId: string) => `${PREFIX}${workspaceId}`;
+
+async function load(workspaceId: string): Promise<PadHistoryEntry[]> {
+  const file = await loadJson(keyFor(workspaceId), padHistoryFileSchema);
+  return file?.entries ?? [];
+}
+
+async function save(workspaceId: string, entries: PadHistoryEntry[]): Promise<void> {
+  await saveJson(keyFor(workspaceId), padHistoryFileSchema, { schemaVersion: 1, entries });
+}
+
+export async function list(input: { workspaceId: string }): Promise<PadHistoryEntry[]> {
+  return load(input.workspaceId);
+}
+
+export async function pin(input: { workspaceId: string; padName: string }): Promise<void> {
+  const entries = await load(input.workspaceId);
+  const e = entries.find((x) => x.padName === input.padName);
+  if (e) e.pinned = true;
+  await save(input.workspaceId, entries);
+}
+
+export async function unpin(input: { workspaceId: string; padName: string }): Promise<void> {
+  const entries = await load(input.workspaceId);
+  const e = entries.find((x) => x.padName === input.padName);
+  if (e) e.pinned = false;
+  await save(input.workspaceId, entries);
+}
+
+export async function clearRecent(input: { workspaceId: string }): Promise<void> {
+  const entries = (await load(input.workspaceId)).filter((e) => e.pinned);
+  await save(input.workspaceId, entries);
+}
+
+export async function clearAll(): Promise<void> {
+  const keys = await listKeys();
+  for (const key of keys) {
+    if (key.startsWith(PREFIX)) await removeKey(key);
+  }
+}
+
+/** Used by `state.getInitial()` to bundle history for every known workspace. */
+export async function loadAll(workspaceIds: string[]): Promise<Record<string, PadHistoryEntry[]>> {
+  const result: Record<string, PadHistoryEntry[]> = {};
+  for (const id of workspaceIds) result[id] = await load(id);
+  return result;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+---
+
+## Task 5: Settings store
+
+- [ ] **Step 1: Create `packages/mobile/src/platform/storage/settings-store.ts`**
+
+```typescript
+import type { Settings } from '@shared/types/settings';
+import { defaultSettings, settingsSchema } from '@shared/validation/settings';
+import { loadJson, saveJson } from './preferences.js';
+
+const KEY = 'etherpad:settings';
+
+export async function get(): Promise<Settings> {
+  const stored = await loadJson(KEY, settingsSchema);
+  return stored ?? defaultSettings;
+}
+
+export async function update(patch: Partial<Settings>): Promise<Settings> {
+  const current = await get();
+  const next: Settings = { ...current, ...patch, schemaVersion: 1 };
+  await saveJson(KEY, settingsSchema, next);
+  return next;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+---
+
+## Task 6: Wire stores into `createCapacitorPlatform`
+
+- [ ] **Step 1: Refactor `packages/mobile/src/platform/capacitor.ts`**
+
+Replace the stub workspace / padHistory / settings / state methods with calls to the stores. Tab / window / httpLogin / updater / quickSwitcher remain stubbed per the decisions above. All return the IPC envelope shape (`{ ok: true, value }`) when going through `unwrap`.
+
+```typescript
+import type { Platform } from '@etherpad/shell';
+import * as workspaceStore from './storage/workspace-store.js';
+import * as padHistoryStore from './storage/pad-history-store.js';
+import * as settingsStore from './storage/settings-store.js';
+
+export function createCapacitorPlatform(): Platform {
+  const ok = Promise.resolve({ ok: true });
+  const okValue = <T>(value: T) => Promise.resolve({ ok: true, value });
+  const wrap = async <T>(fn: () => Promise<T>) => {
+    try {
+      const value = await fn();
+      return { ok: true, value };
+    } catch (err) {
+      return {
+        ok: false,
+        error: {
+          kind: 'UnknownError',
+          message: err instanceof Error ? err.message : String(err),
+        },
+      };
+    }
+  };
+  const notImpl = (op: string) =>
+    Promise.resolve({
+      ok: false,
+      error: { kind: 'NotImplementedError', message: `[mobile] ${op} not implemented yet` },
+    });
+  const noopUnsubscribe = (): (() => void) => () => {};
+
+  return {
+    state: {
+      getInitial: async () => {
+        const { workspaces, order } = await workspaceStore.list();
+        const settings = await settingsStore.get();
+        const padHistory = await padHistoryStore.loadAll(order);
+        return {
+          ok: true,
+          value: {
+            workspaces,
+            workspaceOrder: order,
+            settings,
+            padHistory,
+          },
+        };
+      },
+    },
+    workspace: {
+      list: () => wrap(workspaceStore.list),
+      add: (input) => wrap(() => workspaceStore.add(input)),
+      update: (input) => wrap(() => workspaceStore.update(input)),
+      remove: (input) => wrap(async () => { await workspaceStore.remove(input); return { ok: true } as const; }),
+      reorder: (input) => wrap(() => workspaceStore.reorder(input)),
+    },
+    tab: {
+      open: () => notImpl('tab.open'),
+      close: () => notImpl('tab.close'),
+      focus: () => notImpl('tab.focus'),
+      reload: () => notImpl('tab.reload'),
+      hardReload: () => notImpl('tab.hardReload'),
+    },
+    window: {
+      setActiveWorkspace: () => ok,
+      reloadShell: () => { window.location.reload(); return ok; },
+      setPadViewsHidden: () => ok,
+      setRailCollapsed: () => ok,
+    },
+    padHistory: {
+      list: (input) => wrap(() => padHistoryStore.list(input)),
+      pin: (input) => wrap(async () => { await padHistoryStore.pin(input); return { ok: true } as const; }),
+      unpin: (input) => wrap(async () => { await padHistoryStore.unpin(input); return { ok: true } as const; }),
+      clearRecent: (input) => wrap(async () => { await padHistoryStore.clearRecent(input); return { ok: true } as const; }),
+      clearAll: () => wrap(async () => { await padHistoryStore.clearAll(); return { ok: true } as const; }),
+    },
+    settings: {
+      get: () => wrap(settingsStore.get),
+      update: (patch) => wrap(() => settingsStore.update(patch)),
+    },
+    httpLogin: { respond: () => notImpl('httpLogin.respond') },
+    updater: {
+      checkNow: () => notImpl('updater.checkNow'),
+      installAndRestart: () => notImpl('updater.installAndRestart'),
+      getState: () => Promise.resolve({ kind: 'unsupported', reason: 'mobile' }),
+    },
+    quickSwitcher: { searchPadContent: () => Promise.resolve([]) },
+    events: {
+      onWorkspacesChanged: noopUnsubscribe,
+      onPadHistoryChanged: noopUnsubscribe,
+      onTabsChanged: noopUnsubscribe,
+      onTabState: noopUnsubscribe,
+      onSettingsChanged: noopUnsubscribe,
+      onHttpLoginRequest: noopUnsubscribe,
+      onUpdaterState: noopUnsubscribe,
+      onPadFastSwitch: noopUnsubscribe,
+      onMenuShellMessage: noopUnsubscribe,
+    },
+  };
+}
+```
+
+Note on imports: paths like `@shared/validation/workspace` need the mobile tsconfig's `paths` to resolve `@shared/*` to `../shell/src/*`. If that alias isn't set on mobile, use `@etherpad/shell/...` subpath exports OR fall back to relative paths (`../../../../shell/src/validation/workspace.js`). The cleanest fix is adding the `@shared` alias to mobile's tsconfig and Vite config — matches desktop's pattern.
+
+- [ ] **Step 2: Add `@shared` alias to mobile's Vite + tsconfig**
+
+- [ ] **Step 3: Typecheck + build + commit**
+
+---
+
+## Task 7: Persistence smoke test
+
+- [ ] **Step 1: Extend `packages/mobile/tests/smoke.spec.ts`**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('mobile bundle boots: shell mounts and shows the first-launch AddWorkspaceDialog', async ({ page }) => {
+  await page.goto('/');
+  const heading = page.getByRole('heading', { name: /add an etherpad instance/i });
+  await expect(heading).toBeVisible({ timeout: 15_000 });
+});
+
+test('persisted workspaces hydrate the rail and skip the empty-state dialog', async ({ page }) => {
+  // Seed Capacitor Preferences (web fallback = localStorage with CapacitorStorage. prefix).
+  await page.addInitScript(() => {
+    const wsFile = {
+      schemaVersion: 1,
+      workspaces: [
+        { id: '00000000-0000-4000-8000-000000000001', name: 'Acme', serverUrl: 'https://acme.example/', color: '#3366cc', createdAt: 1 },
+      ],
+      order: ['00000000-0000-4000-8000-000000000001'],
+    };
+    localStorage.setItem('CapacitorStorage.etherpad:workspaces', JSON.stringify(wsFile));
+  });
+  await page.goto('/');
+
+  // Rail shows the workspace; AddWorkspaceDialog is NOT visible.
+  await expect(page.getByRole('button', { name: /open instance acme/i })).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByRole('heading', { name: /add an etherpad instance/i })).not.toBeVisible();
+});
+```
+
+- [ ] **Step 2: Run locally**
+
+```bash
+pnpm --filter @etherpad/mobile test
+```
+
+Both tests should pass.
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Task 8: Open PR + monitor CI + Qodo
+
+Stacked off main (Phase 3 just merged).

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -21,6 +21,7 @@
     "@capacitor/android": "^8.0.0",
     "@capacitor/app": "^8.0.0",
     "@capacitor/core": "^8.0.0",
+    "@capacitor/preferences": "^8.0.1",
     "@etherpad/shell": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -24,7 +24,8 @@
     "@capacitor/preferences": "^8.0.1",
     "@etherpad/shell": "workspace:*",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@capacitor/cli": "^8.0.0",

--- a/packages/mobile/src/platform/capacitor.ts
+++ b/packages/mobile/src/platform/capacitor.ts
@@ -1,55 +1,72 @@
 import type { Platform } from '@etherpad/shell';
+import * as workspaceStore from './storage/workspace-store.js';
+import * as padHistoryStore from './storage/pad-history-store.js';
+import * as settingsStore from './storage/settings-store.js';
 
 /**
- * Stub `CapacitorPlatform` for Phase 3. Returns empty state for every read
- * so the shell renders its first-launch UI (the non-dismissable
- * `AddWorkspaceDialog`). Write methods reject with NOT_IMPLEMENTED — Phase 4
- * replaces these with `@capacitor/preferences` + `@capacitor/filesystem`.
+ * Concrete `Platform` impl for mobile. Workspace, pad-history, and settings
+ * persistence go through `@capacitor/preferences` (web fallback = localStorage
+ * with `CapacitorStorage.<key>` prefix). Pad rendering (`tab.*`),
+ * desktop-specific surfaces (`httpLogin`, `updater`), and pad-content search
+ * remain stubbed — they land in Phase 5+ alongside `PadIframeStack` and the
+ * deep-links / share / permissions plugin.
  *
- * Events are no-op subscribers: the unsubscribe fn does nothing because
- * nothing ever fires. Mobile is single-window so cross-process events aren't
- * meaningful; Phase 4 may add an in-process mitt bus if components want to
- * fire local events.
- *
- * All reads that flow through `ipc.ts`'s `unwrap()` helper return the
- * `{ ok: true, value: ... }` IPC envelope shape. Methods that bypass
- * unwrap (`updater.getState`, `quickSwitcher.searchPadContent`, the events)
- * return raw values per the shell's type contract.
+ * All write paths funnel through `wrap()` so a thrown error inside a store
+ * surfaces to the shell as a typed `{ ok: false, error: ... }` envelope
+ * (consumed by `ipc.ts`'s `unwrap()`).
  */
 export function createCapacitorPlatform(): Platform {
   const ok = Promise.resolve({ ok: true });
-  const okValue = <T>(value: T) => Promise.resolve({ ok: true, value });
-  const notImpl = (op: string) =>
-    Promise.reject(new Error(`[mobile/Phase 3] ${op} not implemented yet`));
-  const noopUnsubscribe = (): (() => void) => () => {};
-
-  const defaultSettings = {
-    schemaVersion: 1 as const,
-    defaultZoom: 1,
-    accentColor: '#3366cc',
-    language: 'en',
-    rememberOpenTabsOnQuit: true,
-    minimizeToTray: false,
-    themePreference: 'auto' as const,
-    userName: '',
+  const wrap = async <T>(
+    fn: () => Promise<T>,
+  ): Promise<{ ok: true; value: T } | { ok: false; error: { kind: string; message: string } }> => {
+    try {
+      const value = await fn();
+      return { ok: true, value };
+    } catch (err) {
+      return {
+        ok: false,
+        error: {
+          kind: 'UnknownError',
+          message: err instanceof Error ? err.message : String(err),
+        },
+      };
+    }
   };
+  const notImpl = (
+    op: string,
+  ): Promise<{ ok: false; error: { kind: string; message: string } }> =>
+    Promise.resolve({
+      ok: false,
+      error: { kind: 'NotImplementedError', message: `[mobile] ${op} not implemented yet` },
+    });
+  const noopUnsubscribe = (): (() => void) => () => {};
 
   return {
     state: {
       getInitial: () =>
-        okValue({
-          workspaces: [],
-          workspaceOrder: [],
-          settings: defaultSettings,
-          padHistory: {},
+        wrap(async () => {
+          const { workspaces, order } = await workspaceStore.list();
+          const settings = await settingsStore.get();
+          const padHistory = await padHistoryStore.loadAll(order);
+          return {
+            workspaces,
+            workspaceOrder: order,
+            settings,
+            padHistory,
+          };
         }),
     },
     workspace: {
-      list: () => okValue({ workspaces: [], order: [] }),
-      add: () => notImpl('workspace.add'),
-      update: () => notImpl('workspace.update'),
-      remove: () => notImpl('workspace.remove'),
-      reorder: () => notImpl('workspace.reorder'),
+      list: () => wrap(workspaceStore.list),
+      add: (input) => wrap(() => workspaceStore.add(input)),
+      update: (input) => wrap(() => workspaceStore.update(input)),
+      remove: (input) =>
+        wrap(async () => {
+          await workspaceStore.remove(input);
+          return { ok: true } as const;
+        }),
+      reorder: (input) => wrap(() => workspaceStore.reorder(input)),
     },
     tab: {
       open: () => notImpl('tab.open'),
@@ -68,15 +85,32 @@ export function createCapacitorPlatform(): Platform {
       setRailCollapsed: () => ok,
     },
     padHistory: {
-      list: () => okValue([]),
-      pin: () => notImpl('padHistory.pin'),
-      unpin: () => notImpl('padHistory.unpin'),
-      clearRecent: () => notImpl('padHistory.clearRecent'),
-      clearAll: () => notImpl('padHistory.clearAll'),
+      list: (input) => wrap(() => padHistoryStore.list(input)),
+      pin: (input) =>
+        wrap(async () => {
+          await padHistoryStore.pin(input);
+          return { ok: true } as const;
+        }),
+      unpin: (input) =>
+        wrap(async () => {
+          await padHistoryStore.unpin(input);
+          return { ok: true } as const;
+        }),
+      clearRecent: (input) =>
+        wrap(async () => {
+          await padHistoryStore.clearRecent(input);
+          return { ok: true } as const;
+        }),
+      clearAll: () =>
+        wrap(async () => {
+          await padHistoryStore.clearAll();
+          return { ok: true } as const;
+        }),
     },
     settings: {
-      get: () => okValue(defaultSettings),
-      update: () => notImpl('settings.update'),
+      get: () => wrap(settingsStore.get),
+      update: (patch) =>
+        wrap(() => settingsStore.update(patch as Parameters<typeof settingsStore.update>[0])),
     },
     httpLogin: {
       respond: () => notImpl('httpLogin.respond'),

--- a/packages/mobile/src/platform/storage/pad-history-store.ts
+++ b/packages/mobile/src/platform/storage/pad-history-store.ts
@@ -1,0 +1,52 @@
+import type { PadHistoryEntry } from '@shared/types/pad-history';
+import { padHistoryFileSchema } from '@shared/validation/pad-history';
+import { listKeys, loadJson, removeKey, saveJson } from './preferences.js';
+
+const PREFIX = 'etherpad:padHistory:';
+const keyFor = (workspaceId: string): string => `${PREFIX}${workspaceId}`;
+
+async function load(workspaceId: string): Promise<PadHistoryEntry[]> {
+  const file = await loadJson(keyFor(workspaceId), padHistoryFileSchema);
+  return file?.entries ?? [];
+}
+
+async function save(workspaceId: string, entries: PadHistoryEntry[]): Promise<void> {
+  await saveJson(keyFor(workspaceId), padHistoryFileSchema, { schemaVersion: 1, entries });
+}
+
+export async function list(input: { workspaceId: string }): Promise<PadHistoryEntry[]> {
+  return load(input.workspaceId);
+}
+
+export async function pin(input: { workspaceId: string; padName: string }): Promise<void> {
+  const entries = await load(input.workspaceId);
+  const e = entries.find((x) => x.padName === input.padName);
+  if (e) e.pinned = true;
+  await save(input.workspaceId, entries);
+}
+
+export async function unpin(input: { workspaceId: string; padName: string }): Promise<void> {
+  const entries = await load(input.workspaceId);
+  const e = entries.find((x) => x.padName === input.padName);
+  if (e) e.pinned = false;
+  await save(input.workspaceId, entries);
+}
+
+export async function clearRecent(input: { workspaceId: string }): Promise<void> {
+  const entries = (await load(input.workspaceId)).filter((e) => e.pinned);
+  await save(input.workspaceId, entries);
+}
+
+export async function clearAll(): Promise<void> {
+  const keys = await listKeys();
+  for (const key of keys) {
+    if (key.startsWith(PREFIX)) await removeKey(key);
+  }
+}
+
+/** Used by `state.getInitial()` to bundle history for every known workspace. */
+export async function loadAll(workspaceIds: string[]): Promise<Record<string, PadHistoryEntry[]>> {
+  const result: Record<string, PadHistoryEntry[]> = {};
+  for (const id of workspaceIds) result[id] = await load(id);
+  return result;
+}

--- a/packages/mobile/src/platform/storage/pad-history-store.ts
+++ b/packages/mobile/src/platform/storage/pad-history-store.ts
@@ -7,7 +7,11 @@ const keyFor = (workspaceId: string): string => `${PREFIX}${workspaceId}`;
 
 async function load(workspaceId: string): Promise<PadHistoryEntry[]> {
   const file = await loadJson(keyFor(workspaceId), padHistoryFileSchema);
-  return file?.entries ?? [];
+  // Cast at the boundary: Zod's `.optional()` infers `title: string | undefined`
+  // whereas `PadHistoryEntry.title` is `title?: string` (no `| undefined`)
+  // under `exactOptionalPropertyTypes: true`. Same boundary cast as desktop's
+  // pad-history-store.
+  return (file?.entries ?? []) as PadHistoryEntry[];
 }
 
 async function save(workspaceId: string, entries: PadHistoryEntry[]): Promise<void> {

--- a/packages/mobile/src/platform/storage/preferences.ts
+++ b/packages/mobile/src/platform/storage/preferences.ts
@@ -1,0 +1,42 @@
+import { Preferences } from '@capacitor/preferences';
+import type { ZodTypeAny, infer as zInfer } from 'zod';
+
+/**
+ * Read a Preferences key and parse it with the given Zod schema. Returns
+ * `null` when the key is absent or the stored JSON doesn't match the
+ * schema. Callers fall back to a default in that case rather than throw —
+ * preferable to crashing the app on boot if disk data is malformed.
+ */
+export async function loadJson<S extends ZodTypeAny>(
+  key: string,
+  schema: S,
+): Promise<zInfer<S> | null> {
+  const { value } = await Preferences.get({ key });
+  if (value === null) return null;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    const result = schema.safeParse(parsed);
+    return result.success ? (result.data as zInfer<S>) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveJson<S extends ZodTypeAny>(
+  key: string,
+  schema: S,
+  value: zInfer<S>,
+): Promise<void> {
+  // Validate before persisting so we never write a malformed blob.
+  schema.parse(value);
+  await Preferences.set({ key, value: JSON.stringify(value) });
+}
+
+export async function removeKey(key: string): Promise<void> {
+  await Preferences.remove({ key });
+}
+
+export async function listKeys(): Promise<string[]> {
+  const { keys } = await Preferences.keys();
+  return keys;
+}

--- a/packages/mobile/src/platform/storage/settings-store.ts
+++ b/packages/mobile/src/platform/storage/settings-store.ts
@@ -1,0 +1,17 @@
+import type { Settings } from '@shared/types/settings';
+import { defaultSettings, settingsSchema } from '@shared/validation/settings';
+import { loadJson, saveJson } from './preferences.js';
+
+const KEY = 'etherpad:settings';
+
+export async function get(): Promise<Settings> {
+  const stored = await loadJson(KEY, settingsSchema);
+  return stored ?? defaultSettings;
+}
+
+export async function update(patch: Partial<Settings>): Promise<Settings> {
+  const current = await get();
+  const next: Settings = { ...current, ...patch, schemaVersion: 1 };
+  await saveJson(KEY, settingsSchema, next);
+  return next;
+}

--- a/packages/mobile/src/platform/storage/workspace-store.ts
+++ b/packages/mobile/src/platform/storage/workspace-store.ts
@@ -1,0 +1,80 @@
+import type { Workspace } from '@shared/types/workspace';
+import { workspacesFileSchema } from '@shared/validation/workspace';
+import { loadJson, saveJson } from './preferences.js';
+
+const KEY = 'etherpad:workspaces';
+
+export interface WorkspacesFile {
+  schemaVersion: 1;
+  workspaces: Workspace[];
+  order: string[];
+}
+
+async function load(): Promise<WorkspacesFile> {
+  const file = await loadJson(KEY, workspacesFileSchema);
+  return file ?? { schemaVersion: 1, workspaces: [], order: [] };
+}
+
+async function save(file: WorkspacesFile): Promise<void> {
+  await saveJson(KEY, workspacesFileSchema, file);
+}
+
+export async function list(): Promise<{ workspaces: Workspace[]; order: string[] }> {
+  const file = await load();
+  return { workspaces: file.workspaces, order: file.order };
+}
+
+export async function add(input: {
+  name: string;
+  serverUrl?: string;
+  color: string;
+  kind?: 'remote' | 'embedded';
+}): Promise<Workspace> {
+  const file = await load();
+  const ws: Workspace = {
+    id: crypto.randomUUID(),
+    name: input.name,
+    serverUrl: input.serverUrl ?? '',
+    color: input.color,
+    createdAt: Date.now(),
+    ...(input.kind ? { kind: input.kind } : {}),
+  };
+  file.workspaces.push(ws);
+  file.order.push(ws.id);
+  await save(file);
+  return ws;
+}
+
+export async function update(input: {
+  id: string;
+  name?: string;
+  serverUrl?: string;
+  color?: string;
+}): Promise<Workspace> {
+  const file = await load();
+  const ws = file.workspaces.find((w) => w.id === input.id);
+  if (!ws) throw new Error(`Workspace ${input.id} not found`);
+  if (input.name !== undefined) ws.name = input.name;
+  if (input.serverUrl !== undefined) ws.serverUrl = input.serverUrl;
+  if (input.color !== undefined) ws.color = input.color;
+  await save(file);
+  return ws;
+}
+
+export async function remove(input: { id: string }): Promise<void> {
+  const file = await load();
+  file.workspaces = file.workspaces.filter((w) => w.id !== input.id);
+  file.order = file.order.filter((id) => id !== input.id);
+  await save(file);
+}
+
+export async function reorder(input: { order: string[] }): Promise<string[]> {
+  const file = await load();
+  const known = new Set(file.workspaces.map((w) => w.id));
+  for (const id of input.order) {
+    if (!known.has(id)) throw new Error(`Unknown workspace ${id}`);
+  }
+  file.order = input.order;
+  await save(file);
+  return input.order;
+}

--- a/packages/mobile/tests/smoke.spec.ts
+++ b/packages/mobile/tests/smoke.spec.ts
@@ -1,10 +1,40 @@
 import { test, expect } from '@playwright/test';
 
 test('mobile bundle boots: shell mounts and shows the first-launch AddWorkspaceDialog', async ({ page }) => {
+  // No persisted state → AddWorkspaceDialog opens by design.
+  await page.addInitScript(() => {
+    localStorage.clear();
+  });
   await page.goto('/');
-  // The shell auto-opens the non-dismissable AddWorkspaceDialog when
-  // initial.workspaces.length === 0 — which is exactly the stub Platform's
-  // first-launch state. The dialog's H2 reads "Add an Etherpad instance".
   const heading = page.getByRole('heading', { name: /add an etherpad instance/i });
   await expect(heading).toBeVisible({ timeout: 15_000 });
+});
+
+test('persisted workspaces hydrate the rail and skip the empty-state dialog', async ({ page }) => {
+  // Seed Capacitor Preferences (web fallback = localStorage with CapacitorStorage. prefix).
+  await page.addInitScript(() => {
+    const wsFile = {
+      schemaVersion: 1,
+      workspaces: [
+        {
+          id: '00000000-0000-4000-8000-000000000001',
+          name: 'Acme',
+          serverUrl: 'https://acme.example/',
+          color: '#3366cc',
+          createdAt: 1,
+        },
+      ],
+      order: ['00000000-0000-4000-8000-000000000001'],
+    };
+    localStorage.setItem('CapacitorStorage.etherpad:workspaces', JSON.stringify(wsFile));
+  });
+  await page.goto('/');
+
+  // Rail shows the workspace; AddWorkspaceDialog is NOT visible.
+  await expect(
+    page.getByRole('button', { name: /open instance acme/i }),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(
+    page.getByRole('heading', { name: /add an etherpad instance/i }),
+  ).not.toBeVisible();
 });

--- a/packages/mobile/tsconfig.mobile.json
+++ b/packages/mobile/tsconfig.mobile.json
@@ -11,7 +11,7 @@
     "tsBuildInfoFile": "out/mobile/tsconfig.mobile.tsbuildinfo",
     "types": ["vite/client"],
     "paths": {
-      "@shared/*": ["../../shell/src/*"]
+      "@shared/*": ["../shell/src/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],

--- a/packages/mobile/tsconfig.mobile.json
+++ b/packages/mobile/tsconfig.mobile.json
@@ -9,7 +9,10 @@
     "declaration": true,
     "noEmit": false,
     "tsBuildInfoFile": "out/mobile/tsconfig.mobile.tsbuildinfo",
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "paths": {
+      "@shared/*": ["../../shell/src/*"]
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],
   "references": [{ "path": "../shell/tsconfig.shell.json" }]

--- a/packages/mobile/vite.config.ts
+++ b/packages/mobile/vite.config.ts
@@ -1,11 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf8')) as { version: string };
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: { '@shared': resolve('../shell/src') },
+  },
   build: {
     outDir: 'dist',
     sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@capacitor/core':
         specifier: ^8.0.0
         version: 8.3.3
+      '@capacitor/preferences':
+        specifier: ^8.0.1
+        version: 8.0.1(@capacitor/core@8.3.3)
       '@etherpad/shell':
         specifier: workspace:*
         version: link:../shell
@@ -393,6 +396,11 @@ packages:
 
   '@capacitor/core@8.3.3':
     resolution: {integrity: sha512-xx1FIriZQ5jwqEkZwmWQHfXNEn5a9ZLOtdFoJXslh0ian6T/EU+QJtRmZw3KRsmcUV6p5ufczBrzF1rVP8Nu3A==}
+
+  '@capacitor/preferences@8.0.1':
+    resolution: {integrity: sha512-T6no3ebi79XJCk91U3Jp/liJUwgBdvHR+s6vhvPkPxSuch7z3zx5Rv1bdWM6sWruNx+pViuEGqZvbfCdyBvcHQ==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -3628,6 +3636,10 @@ snapshots:
   '@capacitor/core@8.3.3':
     dependencies:
       tslib: 2.8.1
+
+  '@capacitor/preferences@8.0.1(@capacitor/core@8.3.3)':
+    dependencies:
+      '@capacitor/core': 8.3.3
 
   '@csstools/color-helpers@6.0.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.5(react@19.2.5)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@capacitor/cli':
         specifier: ^8.0.0


### PR DESCRIPTION
## Summary

Phase 4 of the mobile rollout (spec §11.4, plan
`docs/superpowers/plans/2026-05-11-etherpad-mobile-phase4-storage.md`):

- New `@capacitor/preferences` dependency on `@etherpad/mobile`.
- New storage layer at `packages/mobile/src/platform/storage/`:
  - `preferences.ts` — small `loadJson` / `saveJson` wrapper with Zod
    validation. Malformed disk data returns null (caller falls back to a
    default) rather than throwing, so a corrupted blob never bricks boot.
  - `workspace-store.ts` — CRUD on `{ workspaces, order }` under the
    `etherpad:workspaces` Preferences key.
  - `pad-history-store.ts` — per-workspace history under
    `etherpad:padHistory:<workspaceId>`.
  - `settings-store.ts` — Settings under `etherpad:settings`, defaults to
    the shell's `defaultSettings`.
- `createCapacitorPlatform()` refactored to call the stores for `state` /
  `workspace` / `padHistory` / `settings`. `tab` / `httpLogin` / `updater` /
  `quickSwitcher` / events remain stubbed (Phase 5+ surface).
- Mobile tsconfig + Vite alias now include `@shared/*` → `../shell/src/*`
  so the storage code can share Zod schemas from `@etherpad/shell`
  verbatim — no duplicate validation.
- New persistence smoke test seeds `localStorage` (the Capacitor Preferences
  web fallback) and asserts the workspace renders in the rail with the
  AddWorkspaceDialog hidden. End-to-end coverage of the read path through
  the Zod-validated store layer.

## What works after this PR

- Workspaces, pad history, and settings persist in `@capacitor/preferences`
  on both web (`vite preview`) and Android (Capacitor WebView).
- Reloading the page re-hydrates the rail without re-prompting for a
  workspace.
- Malformed Preferences data is treated as missing and reset to defaults
  (no crash-loop).
- `pnpm mobile:dev` shows the rail when a workspace exists in
  `localStorage.CapacitorStorage.etherpad:workspaces`.

## What does NOT work yet (intentional)

- Adding a workspace through the UI still requires the URL probe to
  succeed; CORS will block that in a browser. On a real Android device the
  WebView ignores CORS for cross-origin same-tier requests but only when
  the target server allows it. End-to-end "add workspace through dialog →
  refresh → still there" flow lands when Phase 5 wires up pad rendering
  and Phase 6 adds the native deep-link / share / permissions plugin.
- Pad opening, tab focus, tab error states — Phase 5.
- HTTP auth, updater, pad-content search — desktop-specific or
  later-phase.

## Test plan

- [ ] CI green on `pnpm typecheck` across shell + desktop + mobile
- [ ] CI green on `pnpm test` (204 shell + 281 desktop + 2 mobile = 487 total)
- [ ] CI green on `pnpm test:e2e` (Playwright Electron, unchanged surface)
- [ ] Local `pnpm mobile:dev` plus a hand-poke of `localStorage` shows the
      rail hydrating from persisted Preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)