### PR TITLE
feat(mobile): PadIframeStack + tab UX (Phase 5)

### DIFF
--- a/packages/mobile/src/components/PadIframeStack.tsx
+++ b/packages/mobile/src/components/PadIframeStack.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import { useShellStore } from '@etherpad/shell/state';
+import { padUrl } from '@shared/url';
+import { onReload, markLoaded, markError } from '../platform/tabs/tab-store.js';
+
+/**
+ * Mobile pad rendering: one DOM `<iframe>` per open tab, exactly one visible
+ * at a time, all hidden when a dialog is open. Replaces desktop's native
+ * `WebContentsView` model with same invariants:
+ *
+ *  - Iframes stay mounted while their tab is open — switching tabs is
+ *    instant and any in-pad WebSocket survives.
+ *  - When the active workspace changes, iframes for the previous workspace
+ *    unmount (they're filtered out of the rendered set).
+ *  - When a dialog opens, every iframe is hidden so the shell's dialog
+ *    paints unobstructed.
+ *  - `iframe.sandbox` is NOT set — Etherpad needs same-origin behavior
+ *    (per design spec §5).
+ *
+ * Language switching reloads the iframe via a `?lang=<code>` query param
+ * in the src — mirrors desktop's `webContents.loadURL` rule.
+ *
+ * X-Frame-Options DENY isn't handled here yet — Phase 6 adds an
+ * `@capacitor/browser` fallback that opens the pad in the system in-app
+ * browser when embedding is refused.
+ */
+export function PadIframeStack(): React.JSX.Element {
+  const tabs = useShellStore((s) => s.tabs);
+  const activeTabId = useShellStore((s) => s.activeTabId);
+  const activeWorkspaceId = useShellStore((s) => s.activeWorkspaceId);
+  const workspaces = useShellStore((s) => s.workspaces);
+  const openDialog = useShellStore((s) => s.openDialog);
+  const settings = useShellStore((s) => s.settings);
+
+  const workspace = workspaces.find((w) => w.id === activeWorkspaceId);
+  const lang = settings?.language ?? 'en';
+
+  // Per-tab reload counter so platform.tab.reload() forces the iframe to
+  // remount (changing the src isn't enough if the URL is identical).
+  const [reloadKeys, setReloadKeys] = useState<Record<string, number>>({});
+  useEffect(() => {
+    const off = onReload(({ tabId }) => {
+      setReloadKeys((prev) => ({ ...prev, [tabId]: (prev[tabId] ?? 0) + 1 }));
+    });
+    return off;
+  }, []);
+
+  const dialogOpen = openDialog !== null;
+  const visibleTabs = activeWorkspaceId
+    ? tabs.filter((t) => t.workspaceId === activeWorkspaceId)
+    : [];
+
+  if (!workspace) return <></>;
+
+  return (
+    <div
+      data-testid="pad-iframe-stack"
+      style={{ position: 'absolute', inset: 0 }}
+    >
+      {visibleTabs.map((tab) => {
+        const baseSrc = padUrl(workspace.serverUrl, tab.padName);
+        const src = `${baseSrc}?lang=${encodeURIComponent(lang)}`;
+        const isActive = tab.tabId === activeTabId && !dialogOpen;
+        const reloadKey = reloadKeys[tab.tabId] ?? 0;
+        return (
+          <iframe
+            key={`${tab.tabId}#${reloadKey}`}
+            src={src}
+            data-pad-id={tab.tabId}
+            title={tab.title ?? tab.padName}
+            onLoad={() => markLoaded(tab.tabId)}
+            onError={() => markError(tab.tabId, 'iframe load failed')}
+            style={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              border: 'none',
+              display: isActive ? 'block' : 'none',
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/mobile/src/main.tsx
+++ b/packages/mobile/src/main.tsx
@@ -3,14 +3,24 @@ import { createRoot } from 'react-dom/client';
 import { App, setPlatform } from '@etherpad/shell';
 import '@etherpad/shell/styles/index.css';
 import { createCapacitorPlatform } from './platform/capacitor.js';
+import { PadIframeStack } from './components/PadIframeStack.js';
 
 // Wire the platform adapter before App renders. App and every IPC caller
 // inside @etherpad/shell route through getPlatform().
-setPlatform(createCapacitorPlatform());
+const platform = createCapacitorPlatform();
+setPlatform(platform);
+
+// Expose the platform on `window` so Playwright tests can drive tab.open /
+// settings.update / etc. directly without going through dialog flows that
+// hit external servers (the URL probe in AddWorkspaceDialog can't pass under
+// browser CORS). Harmless in production — mobile has no security boundary
+// like desktop's preload, and the underlying Preferences are inspectable
+// anyway via DevTools.
+(window as unknown as { __test_platform?: typeof platform }).__test_platform = platform;
 
 const root = createRoot(document.getElementById('root')!);
 root.render(
   <React.StrictMode>
-    <App />
+    <App padView={<PadIframeStack />} />
   </React.StrictMode>,
 );

--- a/packages/mobile/src/platform/capacitor.ts
+++ b/packages/mobile/src/platform/capacitor.ts
@@ -2,6 +2,7 @@ import type { Platform } from '@etherpad/shell';
 import * as workspaceStore from './storage/workspace-store.js';
 import * as padHistoryStore from './storage/pad-history-store.js';
 import * as settingsStore from './storage/settings-store.js';
+import * as tabStore from './tabs/tab-store.js';
 
 /**
  * Concrete `Platform` impl for mobile. Workspace, pad-history, and settings
@@ -69,11 +70,27 @@ export function createCapacitorPlatform(): Platform {
       reorder: (input) => wrap(() => workspaceStore.reorder(input)),
     },
     tab: {
-      open: () => notImpl('tab.open'),
-      close: () => notImpl('tab.close'),
-      focus: () => notImpl('tab.focus'),
-      reload: () => notImpl('tab.reload'),
-      hardReload: () => notImpl('tab.hardReload'),
+      open: (input) => wrap(async () => tabStore.open(input)),
+      close: (input) =>
+        wrap(async () => {
+          tabStore.close(input.tabId);
+          return { ok: true } as const;
+        }),
+      focus: (input) =>
+        wrap(async () => {
+          tabStore.focus(input.tabId);
+          return { ok: true } as const;
+        }),
+      reload: (input) =>
+        wrap(async () => {
+          tabStore.reload(input.tabId);
+          return { ok: true } as const;
+        }),
+      hardReload: (input) =>
+        wrap(async () => {
+          tabStore.hardReload(input.tabId);
+          return { ok: true } as const;
+        }),
     },
     window: {
       setActiveWorkspace: () => ok,
@@ -128,8 +145,8 @@ export function createCapacitorPlatform(): Platform {
     events: {
       onWorkspacesChanged: noopUnsubscribe,
       onPadHistoryChanged: noopUnsubscribe,
-      onTabsChanged: noopUnsubscribe,
-      onTabState: noopUnsubscribe,
+      onTabsChanged: (l) => tabStore.onTabsChanged(l as Parameters<typeof tabStore.onTabsChanged>[0]),
+      onTabState: (l) => tabStore.onTabState(l as Parameters<typeof tabStore.onTabState>[0]),
       onSettingsChanged: noopUnsubscribe,
       onHttpLoginRequest: noopUnsubscribe,
       onUpdaterState: noopUnsubscribe,

--- a/packages/mobile/src/platform/tabs/tab-store.ts
+++ b/packages/mobile/src/platform/tabs/tab-store.ts
@@ -1,0 +1,169 @@
+import type { OpenTab } from '@shared/types/tab';
+
+/**
+ * In-memory mobile tab state + a thin per-event subscriber list. No
+ * persistence: tab state is ephemeral on mobile (a refresh starts fresh).
+ * Phase 5 only — Phase 7+ may persist `rememberOpenTabsOnQuit`'s effect
+ * once we decide how that maps onto a backgrounded WebView.
+ *
+ * Events are intentionally synchronous: the shell subscribes once at mount
+ * and expects `{ tabs, activeTabId }` payloads matching its own Zustand
+ * `replaceTabs(...)` + `setActiveTabId(...)` API.
+ */
+
+type Listener<P> = (payload: P) => void;
+type Unsubscribe = () => void;
+
+class Emitter<Events extends Record<string, unknown>> {
+  private listeners: { [K in keyof Events]?: Set<Listener<Events[K]>> } = {};
+  on<K extends keyof Events>(key: K, l: Listener<Events[K]>): Unsubscribe {
+    let set = this.listeners[key];
+    if (!set) {
+      set = new Set();
+      this.listeners[key] = set;
+    }
+    set.add(l);
+    return () => set.delete(l);
+  }
+  emit<K extends keyof Events>(key: K, payload: Events[K]): void {
+    this.listeners[key]?.forEach((l) => l(payload));
+  }
+}
+
+export interface TabsChangedPayload {
+  tabs: OpenTab[];
+  activeTabId: string | null;
+}
+export interface TabStatePayload {
+  tabId: string;
+  state: 'loading' | 'loaded' | 'error' | 'crashed';
+  errorMessage?: string;
+  title?: string;
+}
+
+type TabEvents = {
+  tabsChanged: TabsChangedPayload;
+  tabState: TabStatePayload;
+};
+
+const emitter = new Emitter<TabEvents>();
+const tabs = new Map<string, OpenTab>();
+let activeTabId: string | null = null;
+
+function snapshot(): TabsChangedPayload {
+  return { tabs: Array.from(tabs.values()), activeTabId };
+}
+
+function emitChanged(): void {
+  emitter.emit('tabsChanged', snapshot());
+}
+
+function makeTabId(workspaceId: string, padName: string): string {
+  return `${workspaceId}::${padName}`;
+}
+
+export function listAll(): OpenTab[] {
+  return Array.from(tabs.values());
+}
+
+export function getActiveTabId(): string | null {
+  return activeTabId;
+}
+
+export function open(input: {
+  workspaceId: string;
+  padName: string;
+  mode?: 'open' | 'create';
+}): OpenTab {
+  const tabId = makeTabId(input.workspaceId, input.padName);
+  const existing = tabs.get(tabId);
+  if (existing) {
+    activeTabId = tabId;
+    emitChanged();
+    return existing;
+  }
+  const tab: OpenTab = {
+    tabId,
+    workspaceId: input.workspaceId,
+    padName: input.padName,
+    title: input.padName,
+    state: 'loading',
+  };
+  tabs.set(tabId, tab);
+  activeTabId = tabId;
+  emitChanged();
+  return tab;
+}
+
+export function close(tabId: string): void {
+  if (!tabs.delete(tabId)) return;
+  if (activeTabId === tabId) {
+    const remaining = Array.from(tabs.keys());
+    activeTabId = remaining[remaining.length - 1] ?? null;
+  }
+  emitChanged();
+}
+
+export function focus(tabId: string): void {
+  if (!tabs.has(tabId)) return;
+  activeTabId = tabId;
+  emitChanged();
+}
+
+/** "Reload" on mobile is a hint to the iframe; PadIframeStack consumes
+ *  this by bumping a per-tab reload key. We model that as an event the
+ *  shell DOES NOT subscribe to but PadIframeStack does. */
+const reloadEmitter = new Emitter<{ reload: { tabId: string } }>();
+export function reload(tabId: string): void {
+  if (!tabs.has(tabId)) return;
+  reloadEmitter.emit('reload', { tabId });
+}
+export function onReload(l: (payload: { tabId: string }) => void): Unsubscribe {
+  return reloadEmitter.on('reload', l);
+}
+
+/** "Hard reload" — currently same effect as reload on mobile (no service
+ *  worker cache to bypass in v1). Distinct method so the shell's IPC
+ *  contract stays consistent. */
+export function hardReload(tabId: string): void {
+  reload(tabId);
+}
+
+export function onTabsChanged(l: Listener<TabsChangedPayload>): Unsubscribe {
+  // Fire once on subscribe so subscribers don't need a separate "initial"
+  // read path — matches desktop's broadcast-after-subscribe semantics.
+  queueMicrotask(() => l(snapshot()));
+  return emitter.on('tabsChanged', l);
+}
+
+export function onTabState(l: Listener<TabStatePayload>): Unsubscribe {
+  return emitter.on('tabState', l);
+}
+
+/** Called by PadIframeStack when an iframe fires its `load` event. */
+export function markLoaded(tabId: string, title?: string): void {
+  const tab = tabs.get(tabId);
+  if (!tab) return;
+  tab.state = 'loaded';
+  if (title) tab.title = title;
+  emitter.emit('tabState', {
+    tabId,
+    state: 'loaded',
+    ...(title ? { title } : {}),
+  });
+}
+
+/** Called by PadIframeStack when an iframe errors (incl. X-Frame DENY). */
+export function markError(tabId: string, errorMessage: string): void {
+  const tab = tabs.get(tabId);
+  if (!tab) return;
+  tab.state = 'error';
+  tab.errorMessage = errorMessage;
+  emitter.emit('tabState', { tabId, state: 'error', errorMessage });
+}
+
+/** Test-only: reset everything between Playwright tests. */
+export function __resetForTests(): void {
+  tabs.clear();
+  activeTabId = null;
+}

--- a/packages/mobile/tests/smoke.spec.ts
+++ b/packages/mobile/tests/smoke.spec.ts
@@ -1,7 +1,27 @@
 import { test, expect } from '@playwright/test';
 
+const WS_ID = '00000000-0000-4000-8000-000000000001';
+
+// Hard-coded UUID — addInitScript serialises this function's source, so it
+// can't close over Node-side constants.
+function seedWorkspace(): void {
+  const wsFile = {
+    schemaVersion: 1,
+    workspaces: [
+      {
+        id: '00000000-0000-4000-8000-000000000001',
+        name: 'Acme',
+        serverUrl: 'https://acme.example/',
+        color: '#3366cc',
+        createdAt: 1,
+      },
+    ],
+    order: ['00000000-0000-4000-8000-000000000001'],
+  };
+  localStorage.setItem('CapacitorStorage.etherpad:workspaces', JSON.stringify(wsFile));
+}
+
 test('mobile bundle boots: shell mounts and shows the first-launch AddWorkspaceDialog', async ({ page }) => {
-  // No persisted state → AddWorkspaceDialog opens by design.
   await page.addInitScript(() => {
     localStorage.clear();
   });
@@ -11,30 +31,72 @@ test('mobile bundle boots: shell mounts and shows the first-launch AddWorkspaceD
 });
 
 test('persisted workspaces hydrate the rail and skip the empty-state dialog', async ({ page }) => {
-  // Seed Capacitor Preferences (web fallback = localStorage with CapacitorStorage. prefix).
-  await page.addInitScript(() => {
-    const wsFile = {
-      schemaVersion: 1,
-      workspaces: [
-        {
-          id: '00000000-0000-4000-8000-000000000001',
-          name: 'Acme',
-          serverUrl: 'https://acme.example/',
-          color: '#3366cc',
-          createdAt: 1,
-        },
-      ],
-      order: ['00000000-0000-4000-8000-000000000001'],
-    };
-    localStorage.setItem('CapacitorStorage.etherpad:workspaces', JSON.stringify(wsFile));
-  });
+  await page.addInitScript(seedWorkspace);
   await page.goto('/');
 
-  // Rail shows the workspace; AddWorkspaceDialog is NOT visible.
   await expect(
     page.getByRole('button', { name: /open instance acme/i }),
   ).toBeVisible({ timeout: 15_000 });
   await expect(
     page.getByRole('heading', { name: /add an etherpad instance/i }),
   ).not.toBeVisible();
+});
+
+test('opening a pad mounts an iframe in PadIframeStack with the right src + lang', async ({ page }) => {
+  await page.addInitScript(seedWorkspace);
+  await page.goto('/');
+
+  // Wait for the rail (= hydrate finished) before driving the platform.
+  await expect(
+    page.getByRole('button', { name: /open instance acme/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Drive the platform directly — going through the OpenPadDialog adds
+  // friction without testing anything new at this layer.
+  await page.evaluate(async ({ wsId }) => {
+    const platform = (window as unknown as { __test_platform: {
+      tab: {
+        open(input: { workspaceId: string; padName: string; mode?: 'open' | 'create' }): Promise<unknown>;
+      };
+    } }).__test_platform;
+    await platform.tab.open({ workspaceId: wsId, padName: 'hello' });
+  }, { wsId: WS_ID });
+
+  // PadIframeStack should render an iframe whose data-pad-id matches the
+  // synthesised tab id (workspaceId::padName), with the correct src.
+  const tabId = `${WS_ID}::hello`;
+  const iframe = page.locator(`iframe[data-pad-id="${tabId}"]`);
+  await expect(iframe).toBeAttached({ timeout: 5_000 });
+  await expect(iframe).toHaveAttribute('src', 'https://acme.example/p/hello?lang=en');
+  // Visible because it's the active tab and no dialog is open.
+  await expect(iframe).toBeVisible();
+});
+
+test('opening a dialog hides every pad iframe', async ({ page }) => {
+  await page.addInitScript(seedWorkspace);
+  await page.goto('/');
+  await expect(
+    page.getByRole('button', { name: /open instance acme/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  await page.evaluate(async ({ wsId }) => {
+    const platform = (window as unknown as { __test_platform: {
+      tab: {
+        open(input: { workspaceId: string; padName: string }): Promise<unknown>;
+      };
+    } }).__test_platform;
+    await platform.tab.open({ workspaceId: wsId, padName: 'hello' });
+  }, { wsId: WS_ID });
+
+  const tabId = `${WS_ID}::hello`;
+  const iframe = page.locator(`iframe[data-pad-id="${tabId}"]`);
+  await expect(iframe).toBeVisible({ timeout: 5_000 });
+
+  // Open the Settings dialog via the rail cog (no need to load real settings
+  // — the dialog itself is what we're verifying hides iframes).
+  await page.getByRole('button', { name: /settings/i }).first().click();
+  await expect(
+    page.getByRole('heading', { name: /^settings$/i }),
+  ).toBeVisible({ timeout: 5_000 });
+  await expect(iframe).toBeHidden();
 });

--- a/packages/shell/src/App.tsx
+++ b/packages/shell/src/App.tsx
@@ -43,7 +43,14 @@ function applyFastSwitch(key: string): boolean {
   return true;
 }
 
-export function App(): React.JSX.Element {
+/** Optional slot for runtime-specific pad rendering.
+ *  - Desktop renders nothing; `WebContentsView`s overlay this area natively.
+ *  - Mobile passes `<PadIframeStack />` so pads render as DOM iframes. */
+export interface AppProps {
+  padView?: React.ReactNode;
+}
+
+export function App({ padView }: AppProps = {}): React.JSX.Element {
   const workspaces = useShellStore((s) => s.workspaces);
   const openDialog = useShellStore((s) => s.openDialog);
   const activeWorkspaceId = useShellStore((s) => s.activeWorkspaceId);
@@ -222,6 +229,7 @@ export function App(): React.JSX.Element {
           </div>
           <div style={{ gridColumn: '3', gridRow: '2', position: 'relative' }}>
             {activeTabsForWs.length === 0 ? <EmptyState /> : null}
+            {padView}
             <TabErrorOverlay />
           </div>
         </div>


### PR DESCRIPTION
## Summary

Phase 5 of the mobile rollout (spec §11.5): real pad rendering on mobile
via DOM iframes, mirroring desktop's WebContentsView invariants.

- Shell `App` accepts an optional `padView?: ReactNode` slot inside the
  main-area. Desktop omits it (WebContentsViews still overlay natively);
  mobile passes `<PadIframeStack />`.
- Mobile platform implements real
  `tab.open/close/focus/reload/hardReload`, backed by an in-memory tab
  store with a small typed event bus. The shell subscribes via
  `onTabsChanged` / `onTabState` exactly as it does on desktop — no
  branch in App.tsx.
- `PadIframeStack` renders one `<iframe>` per tab in the active workspace.
  Exactly one visible at a time (= the active tab); all hidden when a
  dialog is open. Iframes stay mounted while their tab is open so
  switching tabs preserves WebSocket state. `iframe.sandbox` is
  deliberately unset — Etherpad needs same-origin behavior (spec §5).
- Language switching threads through `?lang=` in the iframe src.
- `tab.reload` bumps a per-tab key so the iframe remounts even when the
  URL is unchanged.
- Mobile's `main.tsx` exposes `window.__test_platform` so Playwright can
  drive `tab.*` directly — going through `AddWorkspaceDialog` is blocked
  by browser CORS when the URL probe runs against an arbitrary external
  Etherpad.

## Smoke tests added

| Test | What it asserts |
|---|---|
| empty state → AddWorkspaceDialog | unchanged behavior |
| persisted workspace → rail (existing) | hydrate still works |
| **open pad → iframe with right src + lang** | tab.open populates PadIframeStack, src + lang correct |
| **open dialog → iframe hidden** | dialog visibility invariant holds |

## Deferred

- **X-Frame-Options DENY → `@capacitor/browser` fallback.** Phase 6 already
  pulls `@capacitor/browser` in for deep links / share; adding the
  X-Frame fallback alongside keeps the two PRs each small.

## Test plan

- [ ] CI green on `pnpm typecheck` across all 3 packages
- [ ] CI green on `pnpm test` (204 shell + 281 desktop + 4 mobile = 489 total)
- [ ] CI green on `pnpm test:e2e` (Playwright Electron, unchanged surface)
- [ ] No `electron` / `window.etherpadDesktop` imports in `packages/mobile/src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)