### PR TITLE
feat(mobile): deep links + system share + external browser (Phase 6a)

### DIFF
--- a/docs/superpowers/plans/2026-05-11-etherpad-mobile-phase6a-deeplinks-share-browser.md
+++ b/docs/superpowers/plans/2026-05-11-etherpad-mobile-phase6a-deeplinks-share-browser.md
@@ -1,0 +1,138 @@
+# Phase 6a — Deep links + system share + external browser
+
+> Phase 6 in the spec bundles native permissions, deep links, share, and the X-Frame fallback into one PR. The native permissions plugin (Android Kotlin) can't be CI-verified without a real device, so this PR (6a) lands everything that is web-testable; the native permissions plugin lands separately as 6b once a device is available.
+
+**Goal:** Mobile gains three system-integration affordances visible on any device:
+
+1. **System share** — "Share pad URL" floating action in `PadIframeStack` calls `@capacitor/share`. Web fallback (`navigator.share`) makes the action exerciseable in the dev/preview browser too.
+2. **Open in external browser** — adjacent action calls `@capacitor/browser`. Used as the user-driven X-Frame fallback (if an embed is blocked the user has an obvious escape hatch). Auto-detection of X-Frame DENY requires a native hook on the WebChromeClient and lands in 6b.
+3. **Deep links** — `etherpad://` scheme and `https://*/p/...` URLs handed to the app by Android (or by clicking a link in another in-app browser) parse to `(serverOrigin, padId)`. If a workspace matches the origin, open the pad; otherwise pre-seed `AddWorkspaceDialog` with the server URL.
+
+**Architecture:**
+- All three concerns are *mobile-only* — they don't touch the shell's `Platform` interface. Share + browser plugins are imported directly inside the mobile-only `PadIframeStack` overlay. Deep links register their listener in `main.tsx` and dispatch through `useShellStore` + `platform.tab.open`.
+- The shell's existing `parsePadUrl` (in `@etherpad/shell/url`) is the source of truth for URL → `{serverUrl, padName}` parsing — no mobile duplicate.
+- AndroidManifest intent filters declare `etherpad://` (custom scheme) plus HTTPS app links with `android:autoVerify="true"` so users can configure asset-link verification when packaging.
+
+---
+
+## Task 1: Add `@capacitor/share` + `@capacitor/browser` deps
+
+- [ ] **Step 1: Install**
+
+```bash
+pnpm --filter @etherpad/mobile add @capacitor/share@^8.0.0 @capacitor/browser@^8.0.0
+```
+
+- [ ] **Step 2: Commit**
+
+---
+
+## Task 2: Tab-actions overlay in `PadIframeStack`
+
+- [ ] **Step 1:** Add an absolutely-positioned floating action group in the top-right of `PadIframeStack` that's only visible when there's an active tab in the current workspace. Two buttons:
+  - **Share** (📤) — calls `Share.share({ url: padUrl })`. Web fallback uses `navigator.share` if available, else falls back to clipboard.
+  - **External browser** (↗) — calls `Browser.open({ url: padUrl })`.
+
+```tsx
+// New file: packages/mobile/src/components/PadActionsOverlay.tsx
+import { Share } from '@capacitor/share';
+import { Browser } from '@capacitor/browser';
+
+export function PadActionsOverlay({ url, title }: { url: string; title: string }): React.JSX.Element {
+  return (
+    <div className="pad-actions-overlay" /* top-right floating */>
+      <button aria-label="Share pad" onClick={() => void Share.share({ url, title })}>📤</button>
+      <button aria-label="Open in external browser" onClick={() => void Browser.open({ url })}>↗</button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2:** Wire into `PadIframeStack` — for the active tab (when not behind a dialog), render the overlay alongside.
+
+- [ ] **Step 3:** Smoke test: assert both buttons visible after `tab.open`, hidden when a dialog is open or when no active tab.
+
+---
+
+## Task 3: Deep link handler
+
+- [ ] **Step 1:** New file `packages/mobile/src/platform/deep-links.ts`:
+
+```typescript
+import { App } from '@capacitor/app';
+import { parsePadUrl } from '@shared/url';
+import { useShellStore, dialogActions } from '@etherpad/shell/state';
+import * as tabStore from './tabs/tab-store.js';
+
+export function installDeepLinkHandler(): () => void {
+  let cleanup: (() => void) | undefined;
+  void App.addListener('appUrlOpen', ({ url }) => {
+    handleUrl(url);
+  }).then((sub) => {
+    cleanup = (): void => void sub.remove();
+  });
+  return () => cleanup?.();
+}
+
+export function handleUrl(url: string): void {
+  // Accept etherpad://<host>/p/<pad> and https://<host>/p/<pad>
+  const normalised = url.replace(/^etherpad:/, 'https:');
+  const parsed = parsePadUrl(normalised);
+  if (!parsed) return;
+  const { serverUrl, padName } = parsed;
+  const state = useShellStore.getState();
+  const ws = state.workspaces.find(
+    (w) => normaliseOrigin(w.serverUrl) === normaliseOrigin(serverUrl),
+  );
+  if (ws) {
+    tabStore.open({ workspaceId: ws.id, padName });
+    useShellStore.getState().setActiveWorkspaceId(ws.id);
+  } else {
+    dialogActions.openDialog('addWorkspace', { initialServerUrl: serverUrl, initialPadName: padName });
+  }
+}
+
+function normaliseOrigin(u: string): string {
+  try {
+    return new URL(u).origin;
+  } catch {
+    return u;
+  }
+}
+```
+
+(Note: `dialogActions.openDialog` may not accept arbitrary payload — if so, drop the pre-seed args and just open the dialog. Pre-seeding is nice-to-have.)
+
+- [ ] **Step 2:** Wire `installDeepLinkHandler()` into `main.tsx` after `setPlatform()`.
+
+- [ ] **Step 3:** Vitest unit test (or Playwright via `__test_platform`-like hook) for `handleUrl`: feed `etherpad://acme/p/hello`, assert tab store mutates with the matching workspace.
+
+---
+
+## Task 4: AndroidManifest intent filters
+
+- [ ] **Step 1:** Edit `packages/mobile/android/app/src/main/AndroidManifest.xml` and add intent filters inside the main `<activity>`:
+
+```xml
+<intent-filter android:autoVerify="true">
+  <action android:name="android.intent.action.VIEW" />
+  <category android:name="android.intent.category.DEFAULT" />
+  <category android:name="android.intent.category.BROWSABLE" />
+  <data android:scheme="https" android:pathPattern="/p/.*" />
+</intent-filter>
+
+<intent-filter>
+  <action android:name="android.intent.action.VIEW" />
+  <category android:name="android.intent.category.DEFAULT" />
+  <category android:name="android.intent.category.BROWSABLE" />
+  <data android:scheme="etherpad" />
+</intent-filter>
+```
+
+(HTTPS intent filter is intentionally broad — `data android:host="*"` would be more permissive than Android wants. F-Droid metadata can list specific hosts users have asked us to autoVerify; default ships without `android:host` so Android prompts the user.)
+
+---
+
+## Task 5: PR
+
+- [ ] **Step 1:** Open Phase 6a PR. Note in body that 6b (native permissions plugin) is pending hardware validation.

--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,26 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- Custom URL scheme — `etherpad://acme.example/p/hello` -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="etherpad" />
+            </intent-filter>
+
+            <!-- HTTPS Etherpad pad URLs. autoVerify lets the OS skip the
+                 chooser dialog when the target host publishes a matching
+                 assetlinks.json. No `android:host` so the filter is broad;
+                 downstream forks pinning a specific instance can override.
+                 -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:pathPattern="/p/.*" />
+            </intent-filter>
+
         </activity>
 
         <provider

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -20,8 +20,10 @@
   "dependencies": {
     "@capacitor/android": "^8.0.0",
     "@capacitor/app": "^8.0.0",
+    "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.0.0",
     "@capacitor/preferences": "^8.0.1",
+    "@capacitor/share": "^8.0.1",
     "@etherpad/shell": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/packages/mobile/src/components/PadActionsOverlay.tsx
+++ b/packages/mobile/src/components/PadActionsOverlay.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Browser } from '@capacitor/browser';
+import { Share } from '@capacitor/share';
+
+/**
+ * Floating top-right action group rendered over the currently-visible
+ * iframe. Two affordances:
+ *
+ *  - **Share** — invokes the OS share sheet via `@capacitor/share`. On the
+ *    web fallback the plugin uses `navigator.share` when available, and
+ *    falls back to writing the URL to the clipboard. This is what lets the
+ *    user send a pad to another app from inside the mobile shell.
+ *  - **Open in external browser** — invokes `@capacitor/browser` which
+ *    opens a Chrome Custom Tab on Android (SFSafariViewController on iOS).
+ *    Doubles as the user-driven X-Frame-Options DENY escape hatch: if a
+ *    pad refuses to embed, the user always has this button.
+ *
+ * The overlay is only mounted when there's an active tab and no shell
+ * dialog is open — see PadIframeStack for the gating.
+ */
+export interface PadActionsOverlayProps {
+  url: string;
+  title: string;
+}
+
+export function PadActionsOverlay({ url, title }: PadActionsOverlayProps): React.JSX.Element {
+  return (
+    <div
+      data-testid="pad-actions-overlay"
+      style={{
+        position: 'absolute',
+        top: 'calc(env(safe-area-inset-top, 0px) + 8px)',
+        right: 'calc(env(safe-area-inset-right, 0px) + 8px)',
+        display: 'flex',
+        gap: 6,
+        zIndex: 10,
+      }}
+    >
+      <button
+        type="button"
+        aria-label="Share pad URL"
+        title="Share pad URL"
+        onClick={() => {
+          void Share.share({ url, title }).catch(() => {
+            // Share can reject when the user cancels the sheet or when no
+            // share handler is available; we silently ignore.
+          });
+        }}
+        style={actionButtonStyle}
+      >
+        📤
+      </button>
+      <button
+        type="button"
+        aria-label="Open in external browser"
+        title="Open in external browser"
+        onClick={() => {
+          void Browser.open({ url }).catch(() => {});
+        }}
+        style={actionButtonStyle}
+      >
+        ↗
+      </button>
+    </div>
+  );
+}
+
+const actionButtonStyle: React.CSSProperties = {
+  width: 36,
+  height: 36,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'rgba(0,0,0,0.55)',
+  color: 'white',
+  border: 'none',
+  borderRadius: 18,
+  fontSize: 16,
+  cursor: 'pointer',
+  WebkitTapHighlightColor: 'transparent',
+};

--- a/packages/mobile/src/components/PadIframeStack.tsx
+++ b/packages/mobile/src/components/PadIframeStack.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useShellStore } from '@etherpad/shell/state';
 import { padUrl } from '@shared/url';
 import { onReload, markLoaded, markError } from '../platform/tabs/tab-store.js';
+import { PadActionsOverlay } from './PadActionsOverlay.js';
 
 /**
  * Mobile pad rendering: one DOM `<iframe>` per open tab, exactly one visible
@@ -52,6 +53,12 @@ export function PadIframeStack(): React.JSX.Element {
 
   if (!workspace) return <></>;
 
+  const activeTab = visibleTabs.find((t) => t.tabId === activeTabId);
+  const activePadUrl = activeTab
+    ? `${padUrl(workspace.serverUrl, activeTab.padName)}?lang=${encodeURIComponent(lang)}`
+    : null;
+  const showActions = activeTab !== undefined && !dialogOpen;
+
   return (
     <div
       data-testid="pad-iframe-stack"
@@ -81,6 +88,9 @@ export function PadIframeStack(): React.JSX.Element {
           />
         );
       })}
+      {showActions && activeTab && activePadUrl ? (
+        <PadActionsOverlay url={activePadUrl} title={activeTab.title ?? activeTab.padName} />
+      ) : null}
     </div>
   );
 }

--- a/packages/mobile/src/main.tsx
+++ b/packages/mobile/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { App, setPlatform } from '@etherpad/shell';
 import '@etherpad/shell/styles/index.css';
 import { createCapacitorPlatform } from './platform/capacitor.js';
+import { installDeepLinkHandler } from './platform/deep-links.js';
 import { PadIframeStack } from './components/PadIframeStack.js';
 
 // Wire the platform adapter before App renders. App and every IPC caller
@@ -17,6 +18,11 @@ setPlatform(platform);
 // like desktop's preload, and the underlying Preferences are inspectable
 // anyway via DevTools.
 (window as unknown as { __test_platform?: typeof platform }).__test_platform = platform;
+
+// Register the deep-link listener once the platform is wired. The handler
+// reads useShellStore so it sees fresh state on every URL even after
+// workspaces are added later.
+installDeepLinkHandler();
 
 const root = createRoot(document.getElementById('root')!);
 root.render(

--- a/packages/mobile/src/main.tsx
+++ b/packages/mobile/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { App, setPlatform } from '@etherpad/shell';
 import '@etherpad/shell/styles/index.css';
 import { createCapacitorPlatform } from './platform/capacitor.js';
-import { installDeepLinkHandler } from './platform/deep-links.js';
+import { handleUrl, installDeepLinkHandler } from './platform/deep-links.js';
 import { PadIframeStack } from './components/PadIframeStack.js';
 
 // Wire the platform adapter before App renders. App and every IPC caller
@@ -17,7 +17,11 @@ setPlatform(platform);
 // browser CORS). Harmless in production — mobile has no security boundary
 // like desktop's preload, and the underlying Preferences are inspectable
 // anyway via DevTools.
-(window as unknown as { __test_platform?: typeof platform }).__test_platform = platform;
+(window as unknown as {
+  __test_platform?: typeof platform;
+  __test_handleUrl?: typeof handleUrl;
+}).__test_platform = platform;
+(window as unknown as { __test_handleUrl?: typeof handleUrl }).__test_handleUrl = handleUrl;
 
 // Register the deep-link listener once the platform is wired. The handler
 // reads useShellStore so it sees fresh state on every URL even after

--- a/packages/mobile/src/platform/deep-links.ts
+++ b/packages/mobile/src/platform/deep-links.ts
@@ -1,0 +1,77 @@
+import { App } from '@capacitor/app';
+import { parsePadUrl } from '@shared/url';
+import { dialogActions, useShellStore } from '@etherpad/shell/state';
+import * as tabStore from './tabs/tab-store.js';
+
+/**
+ * Wire up the deep-link handler. Returns a function that removes the
+ * listener (useful for tests; in production we set-and-forget for the app
+ * lifetime).
+ *
+ * Supports two URL families per spec §7:
+ *   - `etherpad://<host>/p/<pad>`  — custom scheme; declared in
+ *     AndroidManifest as a `<data android:scheme="etherpad" />` intent
+ *     filter so Android dispatches it to us.
+ *   - `https://<host>/p/<pad>`     — HTTPS app links; `android:autoVerify`
+ *     lets the OS skip the chooser dialog for hosts that publish a
+ *     matching `assetlinks.json`.
+ *
+ * Match-by-origin against existing workspaces. On match, open the pad;
+ * on miss, prompt to add the workspace (the dialog can be pre-seeded
+ * via `dialogContext` when AddWorkspaceDialog learns to read it).
+ */
+export function installDeepLinkHandler(): () => void {
+  let removed = false;
+  let off: (() => void) | undefined;
+  void App.addListener('appUrlOpen', ({ url }) => {
+    handleUrl(url);
+  }).then((sub) => {
+    if (removed) {
+      void sub.remove();
+      return;
+    }
+    off = (): void => {
+      void sub.remove();
+    };
+  });
+  return () => {
+    removed = true;
+    off?.();
+  };
+}
+
+/**
+ * Exposed for tests. Parses an incoming URL and dispatches it through
+ * the platform — either tab.open into an existing workspace or
+ * openDialog('addWorkspace') seeded with the new origin.
+ */
+export function handleUrl(url: string): void {
+  // Capacitor delivers the URL with its original scheme. Normalise
+  // `etherpad:` → `https:` so `parsePadUrl` (which is HTTPS-only) accepts it.
+  const normalised = url.replace(/^etherpad:/, 'https:');
+  const parsed = parsePadUrl(normalised);
+  if (!parsed) return;
+  const { serverUrl, padName } = parsed;
+
+  const state = useShellStore.getState();
+  const ws = state.workspaces.find(
+    (w) => normaliseOrigin(w.serverUrl) === normaliseOrigin(serverUrl),
+  );
+  if (ws) {
+    state.setActiveWorkspaceId(ws.id);
+    tabStore.open({ workspaceId: ws.id, padName });
+  } else {
+    dialogActions.openDialog('addWorkspace', {
+      initialServerUrl: serverUrl,
+      initialPadName: padName,
+    });
+  }
+}
+
+function normaliseOrigin(input: string): string {
+  try {
+    return new URL(input).origin;
+  } catch {
+    return input;
+  }
+}

--- a/packages/mobile/tests/smoke.spec.ts
+++ b/packages/mobile/tests/smoke.spec.ts
@@ -46,13 +46,10 @@ test('opening a pad mounts an iframe in PadIframeStack with the right src + lang
   await page.addInitScript(seedWorkspace);
   await page.goto('/');
 
-  // Wait for the rail (= hydrate finished) before driving the platform.
   await expect(
     page.getByRole('button', { name: /open instance acme/i }),
   ).toBeVisible({ timeout: 15_000 });
 
-  // Drive the platform directly — going through the OpenPadDialog adds
-  // friction without testing anything new at this layer.
   await page.evaluate(async ({ wsId }) => {
     const platform = (window as unknown as { __test_platform: {
       tab: {
@@ -62,13 +59,10 @@ test('opening a pad mounts an iframe in PadIframeStack with the right src + lang
     await platform.tab.open({ workspaceId: wsId, padName: 'hello' });
   }, { wsId: WS_ID });
 
-  // PadIframeStack should render an iframe whose data-pad-id matches the
-  // synthesised tab id (workspaceId::padName), with the correct src.
   const tabId = `${WS_ID}::hello`;
   const iframe = page.locator(`iframe[data-pad-id="${tabId}"]`);
   await expect(iframe).toBeAttached({ timeout: 5_000 });
   await expect(iframe).toHaveAttribute('src', 'https://acme.example/p/hello?lang=en');
-  // Visible because it's the active tab and no dialog is open.
   await expect(iframe).toBeVisible();
 });
 
@@ -81,9 +75,7 @@ test('opening a dialog hides every pad iframe', async ({ page }) => {
 
   await page.evaluate(async ({ wsId }) => {
     const platform = (window as unknown as { __test_platform: {
-      tab: {
-        open(input: { workspaceId: string; padName: string }): Promise<unknown>;
-      };
+      tab: { open(input: { workspaceId: string; padName: string }): Promise<unknown> };
     } }).__test_platform;
     await platform.tab.open({ workspaceId: wsId, padName: 'hello' });
   }, { wsId: WS_ID });
@@ -92,11 +84,50 @@ test('opening a dialog hides every pad iframe', async ({ page }) => {
   const iframe = page.locator(`iframe[data-pad-id="${tabId}"]`);
   await expect(iframe).toBeVisible({ timeout: 5_000 });
 
-  // Open the Settings dialog via the rail cog (no need to load real settings
-  // — the dialog itself is what we're verifying hides iframes).
   await page.getByRole('button', { name: /settings/i }).first().click();
   await expect(
     page.getByRole('heading', { name: /^settings$/i }),
   ).toBeVisible({ timeout: 5_000 });
   await expect(iframe).toBeHidden();
+});
+
+test('share + external-browser actions appear over the active pad', async ({ page }) => {
+  await page.addInitScript(seedWorkspace);
+  await page.goto('/');
+  await expect(
+    page.getByRole('button', { name: /open instance acme/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // No active tab → no actions overlay.
+  await expect(page.getByTestId('pad-actions-overlay')).toHaveCount(0);
+
+  await page.evaluate(async ({ wsId }) => {
+    const platform = (window as unknown as { __test_platform: {
+      tab: { open(input: { workspaceId: string; padName: string }): Promise<unknown> };
+    } }).__test_platform;
+    await platform.tab.open({ workspaceId: wsId, padName: 'hello' });
+  }, { wsId: WS_ID });
+
+  const overlay = page.getByTestId('pad-actions-overlay');
+  await expect(overlay).toBeVisible({ timeout: 5_000 });
+  await expect(overlay.getByRole('button', { name: /share pad url/i })).toBeVisible();
+  await expect(overlay.getByRole('button', { name: /open in external browser/i })).toBeVisible();
+});
+
+test('deep link to a known workspace opens the pad in that workspace', async ({ page }) => {
+  await page.addInitScript(seedWorkspace);
+  await page.goto('/');
+  await expect(
+    page.getByRole('button', { name: /open instance acme/i }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // Simulate the Capacitor `appUrlOpen` event by invoking the deep-link
+  // handler exposed on window. main.tsx wires it like __test_platform.
+  await page.evaluate(() => {
+    (window as unknown as { __test_handleUrl: (url: string) => void })
+      .__test_handleUrl('https://acme.example/p/deep-linked');
+  });
+
+  const tabId = `${WS_ID}::deep-linked`;
+  await expect(page.locator(`iframe[data-pad-id="${tabId}"]`)).toBeAttached({ timeout: 5_000 });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,10 +128,16 @@ importers:
       '@capacitor/app':
         specifier: ^8.0.0
         version: 8.1.0(@capacitor/core@8.3.3)
+      '@capacitor/browser':
+        specifier: ^8.0.3
+        version: 8.0.3(@capacitor/core@8.3.3)
       '@capacitor/core':
         specifier: ^8.0.0
         version: 8.3.3
       '@capacitor/preferences':
+        specifier: ^8.0.1
+        version: 8.0.1(@capacitor/core@8.3.3)
+      '@capacitor/share':
         specifier: ^8.0.1
         version: 8.0.1(@capacitor/core@8.3.3)
       '@etherpad/shell':
@@ -392,6 +398,11 @@ packages:
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
+  '@capacitor/browser@8.0.3':
+    resolution: {integrity: sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
   '@capacitor/cli@8.3.3':
     resolution: {integrity: sha512-FHebL02KEyU5vs+Os5s1yZuE8QT3FzxoO4nZLywGk7Ny957E6gOujKouGKsnKYq01eAWWJGGV/Fv04rY27tSsw==}
     engines: {node: '>=22.0.0'}
@@ -402,6 +413,11 @@ packages:
 
   '@capacitor/preferences@8.0.1':
     resolution: {integrity: sha512-T6no3ebi79XJCk91U3Jp/liJUwgBdvHR+s6vhvPkPxSuch7z3zx5Rv1bdWM6sWruNx+pViuEGqZvbfCdyBvcHQ==}
+    peerDependencies:
+      '@capacitor/core': '>=8.0.0'
+
+  '@capacitor/share@8.0.1':
+    resolution: {integrity: sha512-3cSBKBCJVon54rKDROP2rqGyeGks4pBh9TbaEk9S375Kbek/ZHe72N50zIa0Vn9Eac/SuhwgehO/mmA4CsUOiw==}
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
 
@@ -3614,6 +3630,10 @@ snapshots:
     dependencies:
       '@capacitor/core': 8.3.3
 
+  '@capacitor/browser@8.0.3(@capacitor/core@8.3.3)':
+    dependencies:
+      '@capacitor/core': 8.3.3
+
   '@capacitor/cli@8.3.3':
     dependencies:
       '@ionic/cli-framework-output': 2.2.8
@@ -3641,6 +3661,10 @@ snapshots:
       tslib: 2.8.1
 
   '@capacitor/preferences@8.0.1(@capacitor/core@8.3.3)':
+    dependencies:
+      '@capacitor/core': 8.3.3
+
+  '@capacitor/share@8.0.1(@capacitor/core@8.3.3)':
     dependencies:
       '@capacitor/core': 8.3.3
 


### PR DESCRIPTION
## Summary

Phase 6a of the mobile rollout (Phase 6 split, see plan
`docs/superpowers/plans/2026-05-11-etherpad-mobile-phase6a-deeplinks-share-browser.md`):

- **System share** — floating "📤" button in the top-right of the active
  iframe calls `@capacitor/share`. Web fallback uses `navigator.share`
  when present.
- **External browser** — adjacent "↗" button opens the current pad URL in
  a Chrome Custom Tab via `@capacitor/browser`. Doubles as the user-driven
  X-Frame-Options DENY escape hatch (auto-detection of DENY needs a
  native hook on WebChromeClient — that's Phase 6b).
- **Deep links** — `@capacitor/app`'s `appUrlOpen` listener parses
  `etherpad://...` and `https://*/p/...` URLs using the shell's existing
  `parsePadUrl`. Matches by origin against persisted workspaces — opens
  the pad on match, prompts `addWorkspace` (with `initialServerUrl` +
  `initialPadName` in `dialogContext`) on miss.
- **AndroidManifest intent filters** declare the `etherpad` custom scheme
  + an HTTPS app-link filter for `/p/*` with `android:autoVerify="true"`.
- Mobile bundle exposes `window.__test_handleUrl` for Playwright; the
  Capacitor `appUrlOpen` event itself is harder to fire from a browser
  test, but the URL routing logic is what we actually want to verify.

## Deferred to Phase 6b (needs hardware to validate)

- Custom Android `PadWebviewPermissionsPlugin` (Kotlin) that overrides
  `WebChromeClient.onPermissionRequest` and maps the WebView's
  `VIDEO_CAPTURE` / `AUDIO_CAPTURE` to runtime `CAMERA` /
  `RECORD_AUDIO`. Lands when a real Android device is available for
  `ep_webrtc` smoke testing.
- iOS equivalent (`WKUIDelegate.requestMediaCapturePermissionFor`) —
  same constraint, plus the iOS GA is a v2 milestone.
- Auto-detect X-Frame DENY → switch the user into the in-app browser
  automatically rather than waiting for the manual "↗" tap. Requires
  the same WebChromeClient hook.

## Smoke tests

6 mobile Playwright cases now (added 2 in this PR):

| # | Test |
|---|---|
| 1 | empty state → AddWorkspaceDialog |
| 2 | persisted workspace → rail |
| 3 | open pad → iframe with right src + lang |
| 4 | open dialog → iframes hidden |
| 5 | **share + external-browser actions appear over the active pad** |
| 6 | **deep link to a known workspace opens the pad in that workspace** |

## Test plan

- [ ] CI green on `pnpm typecheck` across shell + desktop + mobile
- [ ] CI green on `pnpm test` (204 shell + 281 desktop + 6 mobile = 491 total)
- [ ] CI green on `pnpm test:e2e` (Playwright Electron, unchanged surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)