### PR TITLE
feat(shell): hide URL when embedded + Open Pad lists pads across all instances + embedded-server roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ marked; everything else lands on both.
 - **Mobile permissions plugin (Phase 6b)** — native Kotlin delegation for
   camera, mic, clipboard, fullscreen, file picker so `ep_webrtc` and friends
   work inside the WebView on Android.
+- **`/admin` for embedded local servers** — when a user picks "Use a local
+  server", expose Etherpad's `/admin` UI in a tab (or a dedicated dialog)
+  so they can install plugins, manage users, and tweak settings against
+  their local instance. Without this, the local server is read-only from
+  the user's perspective.
+- **Pre-compile Etherpad's TS at build time** — today the embedded server
+  uses `tsx/cjs` to transpile every TS file on boot. That spikes RAM hard
+  on cold start (Electron-as-Node parent + tsx + Etherpad's plugin tree)
+  and gets OOM-killed on memory-constrained machines. Shipping a pre-
+  compiled copy of `resources/etherpad/` removes the tsx-at-runtime cost
+  and halves the embedded footprint. Larger ship artifact, smaller RAM.
 - **Desktop permission UX upgrade** — replace the narrow pre-allow with a
   deny-by-default prompt-on-request flow, decisions persisted per
   instance+origin. Same UI ships to mobile after Phase 6b lands.

--- a/packages/shell/src/dialogs/AddWorkspaceDialog.tsx
+++ b/packages/shell/src/dialogs/AddWorkspaceDialog.tsx
@@ -74,16 +74,17 @@ export function AddWorkspaceDialog({ dismissable }: { dismissable: boolean }): R
         </span>
         <input value={name} onChange={(e) => setName(e.target.value)} autoFocus required />
       </label>
-      <label className="dialog-field">
-        <span className="dialog-label">{t.addWorkspace.serverUrlLabel}</span>
-        <input
-          value={serverUrl}
-          onChange={(e) => setServerUrl(e.target.value)}
-          placeholder="https://pads.example.com"
-          disabled={embedded}
-          required={!embedded}
-        />
-      </label>
+      {!embedded && (
+        <label className="dialog-field">
+          <span className="dialog-label">{t.addWorkspace.serverUrlLabel}</span>
+          <input
+            value={serverUrl}
+            onChange={(e) => setServerUrl(e.target.value)}
+            placeholder="https://pads.example.com"
+            required
+          />
+        </label>
+      )}
       <label className="dialog-field-inline">
         <input
           type="checkbox"

--- a/packages/shell/src/dialogs/OpenPadDialog.tsx
+++ b/packages/shell/src/dialogs/OpenPadDialog.tsx
@@ -1,30 +1,92 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { ipc } from '../platform/ipc.js';
 import { dialogActions, useShellStore } from '../state/store.js';
 import { t } from '../i18n/index.js';
 import { DialogShell } from '../components/DialogShell.js';
+import type { PadHistoryEntry } from '@shared/types/pad-history';
+import type { Workspace } from '@shared/types/workspace';
 
-const EMPTY_HISTORY: never[] = [];
+/**
+ * Open-or-create a pad. The text field auto-suggests pads from EVERY
+ * workspace's history (not just the active one) so the user can switch
+ * + open in one action — matching the cross-instance suggestion model
+ * the QuickSwitcher already uses, but framed as "open a pad" so the
+ * primary action stays "create or open by name in the active
+ * workspace" rather than "jump to one you've seen before".
+ *
+ * Behaviour:
+ *  - Typing a name → suggestions: every pad-history entry whose name
+ *    (or whose workspace name) substring-matches, deduped by
+ *    `${workspaceId}::${padName}`, capped at 8. Each row shows the
+ *    workspace colour dot + the workspace name so cross-instance pads
+ *    are unambiguous.
+ *  - Click a suggestion → switch to that workspace (if different) and
+ *    open the pad.
+ *  - Submit (Enter or Open button) → open the typed name in the
+ *    CURRENT active workspace. Etherpad's `/p/<name>` URL is
+ *    open-or-create at the server, so this works whether the pad
+ *    exists or not — the "Create new" checkbox is intentionally gone.
+ */
+
+type Suggestion = { entry: PadHistoryEntry; workspace: Workspace };
 
 export function OpenPadDialog(): React.JSX.Element {
   const wsId = useShellStore((s) => s.activeWorkspaceId);
-  const history = useShellStore((s) => (wsId ? s.padHistory[wsId] ?? EMPTY_HISTORY : EMPTY_HISTORY));
+  const workspaces = useShellStore((s) => s.workspaces);
+  const padHistory = useShellStore((s) => s.padHistory);
   const [name, setName] = useState('');
 
-  const matches = name
-    ? history.filter((e) => e.padName.toLowerCase().includes(name.toLowerCase())).slice(0, 8)
-    : [];
+  const wsById = useMemo(
+    () => new Map(workspaces.map((w) => [w.id, w])),
+    [workspaces],
+  );
 
-  // Etherpad's `/p/<name>` URL is open-or-create: visiting it loads the
-  // pad if it exists or creates it on demand. There's no separate
-  // "create" path in the server, and tab-handlers/tab-store never read
-  // `mode`. The previous "Create new" checkbox was cosmetic; removing
-  // it. `mode` stays on the IPC payload (schema-level default 'open')
-  // so external callers don't break.
-  const submit = async (override?: string) => {
-    const padName = override ?? name;
-    if (!wsId || !padName) return;
-    await ipc.tab.open({ workspaceId: wsId, padName, mode: 'open' });
+  // Flatten all pads across all workspaces, with their workspace
+  // attached. Most-recently-opened first so the suggestions surface
+  // what the user touched recently.
+  const allPads = useMemo<Suggestion[]>(() => {
+    const out: Suggestion[] = [];
+    for (const [id, entries] of Object.entries(padHistory)) {
+      const ws = wsById.get(id);
+      if (!ws) continue;
+      for (const entry of entries) out.push({ entry, workspace: ws });
+    }
+    out.sort((a, b) => b.entry.lastOpenedAt - a.entry.lastOpenedAt);
+    return out;
+  }, [padHistory, wsById]);
+
+  const matches = useMemo<Suggestion[]>(() => {
+    const q = name.trim().toLowerCase();
+    if (!q) return [];
+    return allPads
+      .filter(({ entry, workspace }) => {
+        const padHit = entry.padName.toLowerCase().includes(q)
+          || (entry.title ? entry.title.toLowerCase().includes(q) : false);
+        const wsHit = workspace.name.toLowerCase().includes(q);
+        return padHit || wsHit;
+      })
+      .slice(0, 8);
+  }, [name, allPads]);
+
+  const openSuggestion = async (s: Suggestion): Promise<void> => {
+    // Switch workspace first if the suggestion lives elsewhere — the
+    // tab IPC opens in whatever workspace it's asked, but having the
+    // rail follow the user's selection is the expected UX.
+    if (s.workspace.id !== wsId) {
+      useShellStore.getState().setActiveWorkspaceId(s.workspace.id);
+      await ipc.window.setActiveWorkspace(s.workspace.id);
+    }
+    await ipc.tab.open({
+      workspaceId: s.workspace.id,
+      padName: s.entry.padName,
+      mode: 'open',
+    });
+    dialogActions.closeDialog();
+  };
+
+  const submitTyped = async (): Promise<void> => {
+    if (!wsId || !name.trim()) return;
+    await ipc.tab.open({ workspaceId: wsId, padName: name.trim(), mode: 'open' });
     dialogActions.closeDialog();
   };
 
@@ -33,24 +95,83 @@ export function OpenPadDialog(): React.JSX.Element {
       <h2 id="open-pad-title">{t.openPad.title}</h2>
       <label className="dialog-field">
         <span className="dialog-label">{t.openPad.label}</span>
-        <input value={name} onChange={(e) => setName(e.target.value)} autoFocus />
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && matches[0]) {
+              // Enter on a populated suggestion list opens the first
+              // match — same convention as QuickSwitcher / OS Spotlight.
+              e.preventDefault();
+              void openSuggestion(matches[0]);
+            }
+          }}
+        />
       </label>
       {matches.length > 0 && (
-        <ul role="listbox" style={{ listStyle: 'none', padding: 0, margin: 0, border: '1px solid var(--panel-border)' }}>
-          {matches.map((m) => (
-            <li key={m.padName} role="option" aria-selected={false}>
-              <button type="button" onClick={() => void submit(m.padName)} style={{ width: '100%', textAlign: 'left', padding: 4 }}>
-                {m.padName}
+        <ul
+          role="listbox"
+          style={{ listStyle: 'none', padding: 0, margin: 0, border: '1px solid var(--panel-border)' }}
+        >
+          {matches.map((s) => (
+            <li
+              key={`${s.workspace.id}::${s.entry.padName}`}
+              role="option"
+              aria-selected={false}
+            >
+              <button
+                type="button"
+                onClick={() => void openSuggestion(s)}
+                style={{
+                  width: '100%',
+                  textAlign: 'left',
+                  padding: '6px 8px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  style={{
+                    display: 'inline-block',
+                    width: 10,
+                    height: 10,
+                    borderRadius: '50%',
+                    background: s.workspace.color,
+                    flexShrink: 0,
+                  }}
+                />
+                <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {s.entry.title ?? s.entry.padName}
+                </span>
+                <span
+                  style={{ color: 'var(--text-muted)', fontSize: '0.85em', marginLeft: 'auto' }}
+                >
+                  {s.workspace.name}
+                </span>
               </button>
             </li>
           ))}
         </ul>
       )}
       <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
-        <button className="btn-primary" title={t.openPad.submit} onClick={() => void submit()} disabled={!name}>
+        <button
+          className="btn-primary"
+          title={t.openPad.submit}
+          onClick={() => void submitTyped()}
+          disabled={!name.trim()}
+        >
           {t.openPad.submit}
         </button>
-        <button className="btn-secondary" title={t.addWorkspace.cancel} onClick={() => dialogActions.closeDialog()}>{t.addWorkspace.cancel}</button>
+        <button
+          className="btn-secondary"
+          title={t.addWorkspace.cancel}
+          onClick={() => dialogActions.closeDialog()}
+        >
+          {t.addWorkspace.cancel}
+        </button>
       </div>
     </DialogShell>
   );

--- a/packages/shell/tests/dialogs/OpenPadDialog.spec.tsx
+++ b/packages/shell/tests/dialogs/OpenPadDialog.spec.tsx
@@ -9,15 +9,24 @@ beforeEach(() => {
   useShellStore.setState(useShellStore.getInitialState());
   useShellStore.setState({
     activeWorkspaceId: 'a',
+    workspaces: [
+      { id: 'a', name: 'Alpha', serverUrl: 'https://alpha', color: '#3366cc', createdAt: 1 },
+      { id: 'b', name: 'Beta', serverUrl: 'https://beta', color: '#dc2626', createdAt: 2 },
+    ],
+    workspaceOrder: ['a', 'b'],
     padHistory: {
       a: [
         { workspaceId: 'a', padName: 'standup', lastOpenedAt: 1, pinned: false },
         { workspaceId: 'a', padName: 'standdown', lastOpenedAt: 0, pinned: false },
       ],
+      b: [
+        { workspaceId: 'b', padName: 'standby-cross-instance', lastOpenedAt: 5, pinned: false },
+      ],
     },
   });
   window.etherpadDesktop = {
     tab: { open: vi.fn().mockResolvedValue({ ok: true, value: { tabId: 't' } }) },
+    window: { setActiveWorkspace: vi.fn().mockResolvedValue({ ok: true }) },
   };
 });
 
@@ -34,10 +43,26 @@ describe('OpenPadDialog', () => {
     });
   });
 
-  it('shows autocomplete suggestions matching the input', async () => {
+  it('shows autocomplete suggestions across ALL workspaces, sorted by lastOpenedAt desc', async () => {
     render(<OpenPadDialog />);
     await userEvent.type(screen.getByLabelText(/pad name/i), 'stand');
-    expect(screen.getAllByRole('option').map((o) => o.textContent)).toEqual(['standup', 'standdown']);
+    // Sorted desc by lastOpenedAt: standby-cross-instance(5) → standup(1) → standdown(0).
+    // Each option label = "<padName><workspaceName>" because the rows
+    // render the pad name then the workspace name in a muted suffix.
+    const labels = screen.getAllByRole('option').map((o) => o.textContent);
+    expect(labels).toEqual([
+      'standby-cross-instanceBeta',
+      'standupAlpha',
+      'standdownAlpha',
+    ]);
+  });
+
+  it('filters by workspace name too (typing "beta" surfaces Beta pads)', async () => {
+    render(<OpenPadDialog />);
+    await userEvent.type(screen.getByLabelText(/pad name/i), 'beta');
+    expect(screen.getAllByRole('option').map((o) => o.textContent)).toEqual([
+      'standby-cross-instanceBeta',
+    ]);
   });
 
   it('no "Create new" checkbox — Etherpad auto-creates on open and the checkbox was dead UI', () => {
@@ -63,25 +88,58 @@ describe('OpenPadDialog', () => {
     expect(useShellStore.getState().openDialog).toBeNull();
   });
 
-  it('clicking an autocomplete suggestion calls tab.open with that padName', async () => {
+  it('clicking a same-workspace suggestion calls tab.open with that padName', async () => {
     render(<OpenPadDialog />);
-    await userEvent.type(screen.getByLabelText(/pad name/i), 'stand');
-    const suggestion = screen.getByRole('option', { name: 'standup' });
+    await userEvent.type(screen.getByLabelText(/pad name/i), 'standup');
+    // Each option contains the pad-name button inside it; clicking the
+    // button fires openSuggestion.
+    const suggestion = screen.getAllByRole('option').find((o) => o.textContent?.includes('standupAlpha'))!;
     await userEvent.click(suggestion.querySelector('button')!);
     expect(window.etherpadDesktop.tab.open).toHaveBeenCalledWith({
       workspaceId: 'a',
       padName: 'standup',
       mode: 'open',
     });
+    // Active workspace doesn't change (already on 'a').
+    expect(window.etherpadDesktop.window.setActiveWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('clicking a cross-workspace suggestion switches workspace AND opens the pad', async () => {
+    render(<OpenPadDialog />);
+    await userEvent.type(screen.getByLabelText(/pad name/i), 'standby');
+    const suggestion = screen.getAllByRole('option').find((o) => o.textContent?.includes('Beta'))!;
+    await userEvent.click(suggestion.querySelector('button')!);
+    // Workspace switch fires BEFORE the tab.open, so the rail follows
+    // the user's selection (cross-instance UX).
+    expect(window.etherpadDesktop.window.setActiveWorkspace).toHaveBeenCalledWith({
+      workspaceId: 'b',
+    });
+    expect(window.etherpadDesktop.tab.open).toHaveBeenCalledWith({
+      workspaceId: 'b',
+      padName: 'standby-cross-instance',
+      mode: 'open',
+    });
+    expect(useShellStore.getState().activeWorkspaceId).toBe('b');
   });
 
   it('clicking autocomplete suggestion closes dialog', async () => {
     dialogActions.openDialog('openPad');
     render(<OpenPadDialog />);
-    await userEvent.type(screen.getByLabelText(/pad name/i), 'stand');
-    const suggestion = screen.getByRole('option', { name: 'standup' });
+    await userEvent.type(screen.getByLabelText(/pad name/i), 'standup');
+    const suggestion = screen.getAllByRole('option').find((o) => o.textContent?.includes('standupAlpha'))!;
     await userEvent.click(suggestion.querySelector('button')!);
     await vi.waitFor(() => expect(useShellStore.getState().openDialog).toBeNull());
+  });
+
+  it('Enter on the input opens the first suggestion (Spotlight convention)', async () => {
+    render(<OpenPadDialog />);
+    await userEvent.type(screen.getByLabelText(/pad name/i), 'stand{Enter}');
+    // First suggestion sorted by lastOpenedAt desc is the Beta pad.
+    expect(window.etherpadDesktop.tab.open).toHaveBeenCalledWith({
+      workspaceId: 'b',
+      padName: 'standby-cross-instance',
+      mode: 'open',
+    });
   });
 
   it('successful submit closes the dialog', async () => {


### PR DESCRIPTION
## Summary

Two UX fixes flagged while testing the embedded server locally, plus two roadmap items captured.

### 1. AddWorkspaceDialog: hide URL when "Use a local server"
Previously the URL field was `disabled={embedded}` — visually subtle. Now it's hidden entirely; the dialog reflows when the user ticks embedded.

### 2. Open Pad: list + filter across all instances
- Suggestion list flattens pad-history across **every** workspace, sorted by `lastOpenedAt` desc
- Filter matches both pad name AND workspace name (typing "beta" surfaces Beta's pads)
- Each row gets a workspace colour dot + muted workspace name suffix
- Clicking a cross-workspace suggestion switches the active workspace before opening the pad
- Enter opens the first suggestion (Spotlight convention)
- Submit-by-button still opens-or-creates the typed name in the active workspace — the "type a fresh pad name and go" path is intact

### 3. Roadmap (README "Soon")
- `/admin` UI for embedded local servers so users can install plugins / tweak settings
- Pre-compile Etherpad's TS at build time — the embedded server `tsx/cjs`-transpiles on boot, spiking RAM hard. On memory-constrained machines the kernel OOM-killer terminates the embedded process. Shipping a pre-compiled `resources/etherpad/` tree halves the runtime memory cost.

## Test plan

- [x] `pnpm test` — 209 shell tests pass (was 206, +3 new for cross-instance + workspace-name filter + Enter-opens-first)
- [x] `pnpm typecheck` clean across all packages
- [ ] Manual: Add Etherpad instance → check "Use a local server" → URL field gone
- [ ] Manual: Open Pad → type a name → suggestions span workspaces → click cross-workspace → rail follows + pad opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)