### PR TITLE
fix(release): unbreak Linux deb + Snap + Windows builds post-monorepo

### DIFF
--- a/packages/desktop/build/electron-builder.yml
+++ b/packages/desktop/build/electron-builder.yml
@@ -36,6 +36,15 @@ linux:
     - AppImage
     - deb
     - snap
+  # `package.json#name` is `@etherpad/desktop` (scoped). electron-builder
+  # uses that as the default executable + artifact basename for the deb
+  # and snap targets, and the `/` in the scope becomes a directory in
+  # the output path — so deb/snap builds crash with "Parent directory
+  # does not exist: release/@etherpad". Snap additionally crashes
+  # earlier with "expected argument for flag '--executable'" because
+  # the scoped name doesn't satisfy the snap binary-naming rules.
+  # Pinning a slash-free executable name fixes both.
+  executableName: etherpad-desktop
   category: Office
   icon: build/icons/
   description: Native desktop client for Etherpad

--- a/packages/desktop/scripts/fetch-etherpad.mjs
+++ b/packages/desktop/scripts/fetch-etherpad.mjs
@@ -44,7 +44,16 @@ async function exists(p) {
 
 async function run(cmd, args, opts = {}) {
   return new Promise((resolveP, rejectP) => {
-    const child = spawn(cmd, args, { stdio: 'inherit', ...opts });
+    // On Windows, pnpm/tar/etc. resolve to .cmd or .ps1 shims, and Node's
+    // spawn() won't find them without going through a shell. Use shell:true
+    // on win32 only to avoid Node's DEP0190 warning elsewhere. All cmd/arg
+    // values here are hardcoded by us, so the shell variant is not an
+    // injection risk.
+    const child = spawn(cmd, args, {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+      ...opts,
+    });
     child.on('exit', (code) => {
       if (code === 0) resolveP();
       else rejectP(new Error(`${cmd} ${args.join(' ')} exited ${code}`));


### PR DESCRIPTION
## Summary

v0.4.0 was the first tag built under the new pnpm monorepo layout (PRs #29/#30, May 5). Three of the five release targets failed; only macOS (DMG + ZIP, both arches) and Linux AppImage made it into the draft release.

The three regressions:

1. **Linux `.deb`** — fpm fatal: `Parent directory does not exist: .../release/@etherpad - cannot write to .../release/@etherpad/desktop_0.4.0_amd64.deb`. electron-builder uses `package.json#name` as the default deb artifact path + executable name. The new scoped name `@etherpad/desktop` makes the `/` literal in the output path.

2. **Snap** — `expected argument for flag '--executable'` followed by `ERR_ELECTRON_BUILDER_CANNOT_EXECUTE`. Same cause: the snap `--executable` flag can't carry a scoped name.

3. **Windows** — `[fetch-etherpad] failed: spawn pnpm ENOENT`. The embedded-server fetch script spawns `pnpm` directly, but on Windows pnpm resolves to `pnpm.cmd` and Node's `child_process.spawn` won't find shims without `shell: true`.

## Changes

- \`packages/desktop/build/electron-builder.yml\`: add \`linux.executableName: etherpad-desktop\`. Pins a slash-free name for both deb and snap targets in one move.
- \`packages/desktop/scripts/fetch-etherpad.mjs\`: add \`shell: process.platform === 'win32'\` to the \`spawn\` call. Same pattern used upstream in \`ether/etherpad\`'s \`admin/scripts/gen-api.mjs\`.

## Test plan

- [x] CI must pass (Linux/macOS/Windows unit tests)
- [ ] After merge: re-run the Release + Snap workflows on the v0.4.0 tag (or push v0.4.1 if v0.4.0 retag isn't desirable). Verify the existing v0.4.0 draft release picks up the missing artifacts: \`etherpad-desktop_0.4.0_amd64.deb\`, \`Etherpad-Desktop-Setup-0.4.0.exe\`, \`Etherpad-Desktop-0.4.0-portable.exe\`, \`latest-linux.yml\`, \`latest.yml\`, and the snap goes to the edge channel.

## Notes

- macOS DMG + ZIP + Linux AppImage all succeed at v0.4.0 (already in the draft release) — they use \`productName\`-derived names, not \`package.json#name\`, so they didn't hit the scoped-name bug.
- v0.3.2 worked because it was built before the monorepo move when root \`package.json#name\` was the non-scoped \`etherpad-desktop\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)