### PR TITLE
fix(release): override scoped package name in build via extraMetadata

### DIFF
--- a/packages/desktop/build/electron-builder.yml
+++ b/packages/desktop/build/electron-builder.yml
@@ -2,6 +2,19 @@ appId: org.etherpad.desktop
 productName: Etherpad Desktop
 copyright: Copyright (c) 2026 The Etherpad Foundation
 
+# Override the package.json#name (`@etherpad/desktop`) for build-time
+# artifact templating only. electron-builder uses `${name}` in
+# intermediate paths (deb, snap, the .nsis.7z that NSIS reads) and the
+# scoped name's `/` becomes a literal directory (deb/snap crash with
+# "Parent directory does not exist: release/@etherpad") while the `@`
+# prefix makes 7za interpret the .nsis.7z basename as a `@list-file`
+# argument ("Could not create destination file: No such file or
+# directory"). We can't drop the scope from package.json itself
+# without breaking `pnpm --filter @etherpad/desktop`, so override it
+# just for the build via extraMetadata.
+extraMetadata:
+  name: etherpad-desktop
+
 directories:
   buildResources: build
   output: release


### PR DESCRIPTION
## Summary

Follow-up to #47. That PR fixed:
- ✅ Snap's \`--executable\` flag (via \`linux.executableName\`)
- ✅ Windows \`pnpm ENOENT\` in fetch-etherpad.mjs

But the v0.4.1 rebuild surfaced **three remaining failures** that all share the same root cause: \`package.json#name\` is \`@etherpad/desktop\` (scoped after the monorepo move), and electron-builder's \`\${name}\` token appears in artifact templates we don't control directly:

1. **Linux \`.deb\`** — fpm: \`Parent directory does not exist: release/@etherpad - cannot write to release/@etherpad/desktop_0.4.1_amd64.deb\`. The default \`deb.artifactName\` is \`\${name}_\${version}_\${arch}.\${ext}\`; the \`/\` from the scope makes \`@etherpad/\` a literal directory.
2. **Snap** — mksquashfs: \`Could not create destination file: No such file or directory\` on \`release/@etherpad/desktop_0.4.1_amd64.snap\`. Same shape.
3. **Windows NSIS** — 7za: \`Could not create destination file: No such file or directory\` on \`release\\@etherpaddesktop-0.4.1-x64.nsis.7z\`. The \`@\` prefix triggers 7za's \`@list-file\` convention (read filenames from a file with this name), and the leading \`@\` was kept after the slash was stripped.

## Fix

\`extraMetadata.name: etherpad-desktop\` in the electron-builder config. This overrides \`package.json#name\` at build time only — the workspace package keeps its scoped name so \`pnpm --filter @etherpad/desktop\` and workspace deps continue to work.

This is the single, narrowest place to fix all three at once. Each artifact template that interpolates \`\${name}\` now sees the slash-free \`etherpad-desktop\`.

## Test plan

- [x] CI lint/typecheck/test/e2e on this PR
- [ ] After merge: re-run Release + Snap workflows on v0.4.1 (or push v0.4.2). Expect the missing artifacts to appear: \`etherpad-desktop_0.4.1_amd64.deb\`, \`Etherpad-Desktop-Setup-0.4.1.exe\`, \`Etherpad-Desktop-0.4.1-portable.exe\`, \`latest-linux.yml\`, \`latest.yml\`, and the snap to push to edge.

## Notes

- This is the third post-monorepo build fix. Previous: #47 (executableName + Windows pnpm shell).
- macOS DMG + Linux AppImage already succeed at v0.4.0 / v0.4.1 because their \`artifactName\` overrides use \`\${productName}\`, not \`\${name}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)