### PR TITLE
fix(release): exclude etherpad/bin/ from extraResources (Windows 7za)

### DIFF
--- a/packages/desktop/build/electron-builder.yml
+++ b/packages/desktop/build/electron-builder.yml
@@ -39,6 +39,18 @@ extraResources:
       - '!**/tests/**'
       - '!**/.git/**'
       - '!**/playwright.config.ts'
+      # Etherpad's `bin/` directory contains operator CLI utilities
+      # (compactPad, importSqlFile, etc.) that the embedded server
+      # never invokes at runtime. Its package.json declares a pnpm
+      # workspace symlink to `../src`, and the nested
+      # `bin/node_modules/ep_etherpad-lite/node_modules/<dep>` paths
+      # are pnpm symlinks too. tar/zip preserves the symlinks but
+      # Windows file systems don't follow them after extraction, so
+      # 7za scan-fails with "system cannot find the path specified"
+      # for every dep and exits 1 (warning-as-error), breaking the
+      # Windows NSIS build. Excluding the whole dir is fine —
+      # findBundledEtherpadDir + node/server.ts only need src/.
+      - '!bin/**'
 
 asar: true
 asarUnpack:


### PR DESCRIPTION
## Summary

v0.4.2 cleared **deb / snap / macOS / Linux AppImage** thanks to #47 + #49, but **release-windows still fails**. 7za reports many warnings during the NSIS .nsis.7z packaging:

\`\`\`
.\resources\etherpad\bin\node_modules\ep_etherpad-lite\node_modules\async\
  : The system cannot find the path specified.
.\resources\etherpad\bin\node_modules\ep_etherpad-lite\node_modules\cookie-parser\
  : The system cannot find the path specified.
... 60+ more, one per dep ...
\`\`\`

7za exits 1 on any warning, electron-builder treats that as failure, the NSIS .exe never builds.

## Root cause

Etherpad's \`bin/\` directory is operator CLI utilities (compactPad, importSqlFile, migrateDB, …). Its \`package.json\` declares \`ep_etherpad-lite: workspace:../src\`, and the nested
\`bin/node_modules/ep_etherpad-lite/node_modules/<dep>\` paths are pnpm symlinks. tar -xz preserves them on extract; Linux/macOS follow them, Windows can't.

## Fix

Exclude \`bin/**\` from \`extraResources.filter\`. \`findBundledEtherpadDir\` + \`node/server.ts\` only need \`src/\` at runtime — \`bin/\` was unused payload.

## Out of scope (snap publish, requires manual action)

The snap **build** now succeeds (#49). But the snap-publish step still fails: \`Issues while processing snap: - Waiting for previous upload(s) to complete their review process. ...go to the other upload(s) page in https://dashboard.snapcraft.io/ and click on the 'Reject and remove from review queue' button.\` Earlier v0.4.0 / v0.4.1 attempts got stuck in store review. Once those are rejected on the Snap Store dashboard, the next snap publish will proceed automatically.

## Test plan

- [x] Repo CI (lint/typecheck/test/e2e)
- [ ] After merge: release-please cuts v0.4.3 → tag it → Release workflow's release-windows succeeds, draft v0.4.3 release contains \`Etherpad-Desktop-Setup-0.4.3.exe\` + \`Etherpad-Desktop-0.4.3-portable.exe\` + \`latest.yml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)