### PR TITLE
test: downstream wire-compat (vectors + smoke)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "lint": "pnpm -r --workspace-concurrency=1 lint",
     "format": "pnpm --filter @etherpad/desktop format",
     "test": "pnpm -r --workspace-concurrency=1 test",
+    "test:vectors": "pnpm --filter @etherpad/shell exec vitest run tests/wire/vectors.spec.ts",
+    "test:smoke": "pnpm --filter @etherpad/shell exec vitest run tests/wire/smoke.spec.ts",
     "test:watch": "pnpm --filter @etherpad/desktop test:watch",
     "test:e2e": "pnpm --filter @etherpad/desktop test:e2e",
     "mobile:dev": "pnpm --filter @etherpad/mobile dev",

--- a/packages/shell/tests/fixtures/wire-vectors.json
+++ b/packages/shell/tests/fixtures/wire-vectors.json
@@ -1,0 +1,7 @@
+[
+  {"name":"plain-insert","initialText":"abc\n","changeset":"Z:4>3=3+3$XYZ","pool":{"numToAttrib":{},"nextNum":0},"resultText":"abcXYZ\n"},
+  {"name":"plain-delete","initialText":"abcdef\n","changeset":"Z:7<3=1-3$","pool":{"numToAttrib":{},"nextNum":0},"resultText":"aef\n"},
+  {"name":"formatted-insert","initialText":"abc\n","changeset":"Z:4>4=3*0+4$bold","pool":{"numToAttrib":{"0":["bold","true"]},"nextNum":1},"resultText":"abcbold\n"},
+  {"name":"multiline-insert","initialText":"abc\n","changeset":"Z:4>8=3|2+8$one\ntwo\n","pool":{"numToAttrib":{},"nextNum":0},"resultText":"abcone\ntwo\n\n"},
+  {"name":"attrib-reuse","initialText":"abc\n","changeset":"Z:4>2*0+1=3*0+1$AB","pool":{"numToAttrib":{"0":["bold","true"]},"nextNum":1},"resultText":"AabcB\n"}
+]

--- a/packages/shell/tests/wire/smoke.spec.ts
+++ b/packages/shell/tests/wire/smoke.spec.ts
@@ -82,7 +82,11 @@ describe('live server smoke (shell HTTP contract)', () => {
 
       const got = await api<{ text: string }>('getText', { padID });
       expect(got.code, got.message).toBe(0);
-      expect(got.data.text).toBe(text);
+      // Etherpad guarantees a pad's text ends with exactly one trailing
+      // newline, so setting "X\n" reads back as "X\n\n". Normalize the
+      // trailing newline(s) on both sides before comparing.
+      const trimTrailing = (s: string) => s.replace(/\n*$/, '\n');
+      expect(trimTrailing(got.data.text)).toBe(trimTrailing(text));
     } finally {
       // Guaranteed cleanup even if an assertion above throws; swallow delete
       // errors so cleanup never masks the real failure.

--- a/packages/shell/tests/wire/smoke.spec.ts
+++ b/packages/shell/tests/wire/smoke.spec.ts
@@ -51,13 +51,15 @@ async function api<T>(fn: string, params: Record<string, string>): Promise<ApiRe
 let serverUp = false;
 
 beforeAll(async () => {
-  serverUp = await reachable();
+  // No key means the smoke can't run, so don't waste a network call + timeout
+  // probing reachability — it can't change the (skip) outcome.
+  if (APIKEY) serverUp = await reachable();
 });
 
 describe('live server smoke (shell HTTP contract)', () => {
   it('completes a create -> fetch /p/<pad> -> getText roundtrip', async () => {
     if (!serverUp || !APIKEY) {
-      const why = !serverUp ? `no Etherpad reachable at ${BASE}` : `ETHERPAD_SMOKE_APIKEY not set`;
+      const why = !APIKEY ? `ETHERPAD_SMOKE_APIKEY not set` : `no Etherpad reachable at ${BASE}`;
       console.warn(
         `[smoke] ${why} — skipping live smoke test. ` +
           `Set ETHERPAD_SMOKE_URL + ETHERPAD_SMOKE_APIKEY to run it.`,
@@ -71,16 +73,20 @@ describe('live server smoke (shell HTTP contract)', () => {
     const created = await api<null>('createPad', { padID, text });
     expect(created.code, created.message).toBe(0);
 
-    // The exact URL the shell loads in its webview.
-    const padRes = await fetch(`${BASE}/p/${encodeURIComponent(padID)}`, {
-      signal: AbortSignal.timeout(5000),
-    });
-    expect(padRes.status).toBe(200);
+    try {
+      // The exact URL the shell loads in its webview.
+      const padRes = await fetch(`${BASE}/p/${encodeURIComponent(padID)}`, {
+        signal: AbortSignal.timeout(5000),
+      });
+      expect(padRes.status).toBe(200);
 
-    const got = await api<{ text: string }>('getText', { padID });
-    expect(got.code, got.message).toBe(0);
-    expect(got.data.text).toBe(text);
-
-    await api<null>('deletePad', { padID });
+      const got = await api<{ text: string }>('getText', { padID });
+      expect(got.code, got.message).toBe(0);
+      expect(got.data.text).toBe(text);
+    } finally {
+      // Guaranteed cleanup even if an assertion above throws; swallow delete
+      // errors so cleanup never masks the real failure.
+      await api<null>('deletePad', { padID }).catch(() => {});
+    }
   });
 });

--- a/packages/shell/tests/wire/smoke.spec.ts
+++ b/packages/shell/tests/wire/smoke.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+/**
+ * Downstream wire-compatibility — live smoke test (headless-light).
+ *
+ * Phase 2 of ether/etherpad#7923. This proves the desktop/mobile shell could
+ * talk to a real Etherpad server *without* booting Electron. The full Electron
+ * e2e stays in this repo's own CI; this gate is deliberately headless-light —
+ * a plain HTTP roundtrip against the contract the shell depends on:
+ *   1. create a pad via the HTTP API,
+ *   2. fetch `/p/<pad>` (the exact URL the shell would load in its webview)
+ *      and assert HTTP 200,
+ *   3. read the pad text back via the API to confirm content.
+ *
+ * Env contract:
+ *   - ETHERPAD_SMOKE_URL    server base URL (default http://localhost:9003)
+ *   - ETHERPAD_SMOKE_APIKEY HTTP API key (required to actually run)
+ *
+ * Unless BOTH a reachable server and an API key are present, this SKIPS
+ * cleanly — it must never fail CI for lack of test infrastructure.
+ */
+
+const BASE = (process.env.ETHERPAD_SMOKE_URL || 'http://localhost:9003').replace(/\/$/, '');
+const APIKEY = process.env.ETHERPAD_SMOKE_APIKEY || '';
+const API_VERSION = '1.2.13';
+
+async function reachable(): Promise<boolean> {
+  try {
+    const res = await fetch(`${BASE}/api`, { signal: AbortSignal.timeout(2000) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+interface ApiResponse<T> {
+  code: number;
+  message: string;
+  data: T;
+}
+
+async function api<T>(fn: string, params: Record<string, string>): Promise<ApiResponse<T>> {
+  const qs = new URLSearchParams({ apikey: APIKEY, ...params });
+  const res = await fetch(`${BASE}/api/${API_VERSION}/${fn}?${qs.toString()}`, {
+    signal: AbortSignal.timeout(5000),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as ApiResponse<T>;
+}
+
+let serverUp = false;
+
+beforeAll(async () => {
+  serverUp = await reachable();
+});
+
+describe('live server smoke (shell HTTP contract)', () => {
+  it('completes a create -> fetch /p/<pad> -> getText roundtrip', async () => {
+    if (!serverUp || !APIKEY) {
+      const why = !serverUp ? `no Etherpad reachable at ${BASE}` : `ETHERPAD_SMOKE_APIKEY not set`;
+      console.warn(
+        `[smoke] ${why} — skipping live smoke test. ` +
+          `Set ETHERPAD_SMOKE_URL + ETHERPAD_SMOKE_APIKEY to run it.`,
+      );
+      return; // skip cleanly: never fail the gate without a reachable server + key
+    }
+
+    const padID = `phase2-smoke-${Date.now()}`;
+    const text = 'phase2 wire-compat smoke\n';
+
+    const created = await api<null>('createPad', { padID, text });
+    expect(created.code, created.message).toBe(0);
+
+    // The exact URL the shell loads in its webview.
+    const padRes = await fetch(`${BASE}/p/${encodeURIComponent(padID)}`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(padRes.status).toBe(200);
+
+    const got = await api<{ text: string }>('getText', { padID });
+    expect(got.code, got.message).toBe(0);
+    expect(got.data.text).toBe(text);
+
+    await api<null>('deletePad', { padID });
+  });
+});

--- a/packages/shell/tests/wire/vectors.spec.ts
+++ b/packages/shell/tests/wire/vectors.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+/**
+ * Downstream wire-compatibility — fixture-integrity guard.
+ *
+ * Phase 2 of ether/etherpad#7923. Phase 1 added a canonical wire-format
+ * fixture (`wire-vectors.json`) that every Etherpad client must decode
+ * identically. The Rust/CLI clients re-implement changeset decoding and
+ * therefore run these vectors through their own decoder.
+ *
+ * The desktop/mobile apps are thin shells: they load an Etherpad server URL
+ * and embed CORE'S editor (Ace) inside a webview, so there is NO local
+ * changeset decoder to exercise. This test is therefore a *fixture-integrity
+ * guard* rather than a decode test — it asserts the shape/contract of the
+ * vendored fixture so that:
+ *   - a malformed or empty fixture injected into this repo fails loudly, and
+ *   - the contract the embedded editor relies on is documented in-repo.
+ *
+ * The fixture path is overridable via `ETHERPAD_WIRE_VECTORS`, defaulting to
+ * the vendored copy next to this test.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_VECTORS_PATH = resolve(here, '../fixtures/wire-vectors.json');
+const VECTORS_PATH = process.env.ETHERPAD_WIRE_VECTORS || DEFAULT_VECTORS_PATH;
+
+interface WireVector {
+  name: string;
+  initialText: string;
+  changeset: string;
+  pool: { numToAttrib: Record<string, unknown>; nextNum: number };
+  resultText: string;
+}
+
+function loadVectors(): WireVector[] {
+  const raw = readFileSync(VECTORS_PATH, 'utf8');
+  return JSON.parse(raw) as WireVector[];
+}
+
+describe('wire-vectors fixture integrity', () => {
+  const vectors = loadVectors();
+
+  it('is a non-empty array', () => {
+    expect(Array.isArray(vectors)).toBe(true);
+    expect(vectors.length).toBeGreaterThan(0);
+  });
+
+  it('has unique vector names', () => {
+    const names = vectors.map((v) => v.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  describe.each(vectors.map((v) => [v.name, v] as const))('vector %s', (_name, v) => {
+    it('has all five fields with the right types', () => {
+      expect(typeof v.name).toBe('string');
+      expect(v.name.length).toBeGreaterThan(0);
+      expect(typeof v.initialText).toBe('string');
+      expect(typeof v.changeset).toBe('string');
+      expect(v.changeset.length).toBeGreaterThan(0);
+      expect(typeof v.resultText).toBe('string');
+      expect(typeof v.pool).toBe('object');
+      expect(v.pool).not.toBeNull();
+    });
+
+    it('changeset uses the canonical Z: header', () => {
+      expect(v.changeset.startsWith('Z:')).toBe(true);
+    });
+
+    it('pool.numToAttrib is a plain object and pool.nextNum is a number', () => {
+      expect(typeof v.pool.numToAttrib).toBe('object');
+      expect(v.pool.numToAttrib).not.toBeNull();
+      expect(Array.isArray(v.pool.numToAttrib)).toBe(false);
+      expect(typeof v.pool.nextNum).toBe('number');
+      expect(Number.isInteger(v.pool.nextNum)).toBe(true);
+      expect(v.pool.nextNum).toBeGreaterThanOrEqual(0);
+    });
+
+    it('initialText and resultText are non-empty and newline-terminated', () => {
+      expect(v.initialText.length).toBeGreaterThan(0);
+      expect(v.initialText.endsWith('\n')).toBe(true);
+      expect(v.resultText.length).toBeGreaterThan(0);
+      expect(v.resultText.endsWith('\n')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add downstream wire-compat vectors guard and optional live smoke test
<code>🧪 Tests</code> <code>⚙️ Configuration changes</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Phase 2 of ether/etherpad#7923

Phase 1 (core PR ether/etherpad#7923) added a **canonical wire-format fixture** (`wire-vectors.json`) that every Etherpad client must decode identically. This PR adds the downstream guard for the desktop/mobile shells.

### Why the vectors test is a *fixture-integrity guard* here
The Rust/CLI clients re-implement changeset decoding, so they run these vectors through their own decoders. The **desktop and mobile apps are thin shells** — they load an Etherpad server URL and embed **core's Ace editor** in a webview. There is no local changeset decoder to exercise. So instead of a decode test, `vectors.spec.ts` asserts the **shape/contract** of the vendored fixture:

- every record has the 5 fields (`name`, `initialText`, `changeset`, `pool`, `resultText`) with the right types,
- `pool.numToAttrib` is a plain object and `pool.nextNum` a non-negative integer,
- `initialText` / `resultText` are non-empty and newline-terminated,
- changesets use the canonical `Z:` header, names are unique.

This guards against a malformed/empty fixture being injected into the repo and documents the contract the embedded editor relies on.

### Smoke test (headless-light, by design)
The full Electron e2e stays in this repo's own CI. `smoke.spec.ts` is a deliberately **headless-light** HTTP roundtrip proving the shell could talk to a real server **without booting Electron**:

1. create a pad via the HTTP API,
2. fetch `/p/<pad>` (the exact URL the shell loads in its webview) → assert HTTP 200,
3. `getText` via the API to confirm content.

It **skips cleanly** (never fails CI) unless both a reachable server and an API key are present.

### Env contract
| Var | Default | Purpose |
|-----|---------|---------|
| `ETHERPAD_WIRE_VECTORS` | vendored `packages/shell/tests/fixtures/wire-vectors.json` | override fixture path |
| `ETHERPAD_SMOKE_URL` | `http://localhost:9003` | server base URL for the smoke roundtrip |
| `ETHERPAD_SMOKE_APIKEY` | _(unset)_ | HTTP API key; without it (or a reachable server) the smoke skips |

### Files
- `packages/shell/tests/fixtures/wire-vectors.json` — vendored canonical fixture
- `packages/shell/tests/wire/vectors.spec.ts` — fixture-integrity guard (22 cases)
- `packages/shell/tests/wire/smoke.spec.ts` — live headless-light roundtrip / clean skip
- `package.json` — `test:vectors` and `test:smoke` root scripts

### Verification
- `pnpm run test:vectors` → 22 passed
- `pnpm run test:smoke` (no server / no key) → skips cleanly, suite green
- full `pnpm --filter @etherpad/shell test` → 232 passed; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Vendor canonical wire-vectors fixture and assert its contract/shape stays valid.
• Add optional live HTTP smoke roundtrip that cleanly skips without server+API key.
• Expose focused root scripts to run vectors and smoke tests from CI/dev.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  CI["CI / Developer"] --> PKG["package.json scripts"] --> V["Vitest runner"] --> VEC["vectors.spec.ts"] --> FIX[/"wire-vectors.json"/]
  V --> SMK["smoke.spec.ts"] --> SRV{{"Etherpad server"}} --> EP[/"HTTP API + /p/<pad>"/]

  subgraph Legend
    direction LR
    _proc["Test/process"] ~~~ _io[/"Fixture/IO"/] ~~~ _ext{{"External system"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Provision an ephemeral Etherpad (Docker) for smoke in CI</b></summary>

- ➕ Smoke test runs deterministically in CI (no skips)
- ➕ Catches server-compat regressions earlier and more consistently
- ➖ Adds CI complexity, runtime, and maintenance burden
- ➖ Conflicts with goal of never failing without extra infrastructure

</details>

<details>
<summary><b>2. Mock the server contract (fake /api + /p/)</b></summary>

- ➕ Fully offline and deterministic
- ➕ Fast, no credentials needed
- ➖ Doesn&#x27;t validate real Etherpad behavior
- ➖ Easy for mocks to drift from actual server contract

</details>

<details>
<summary><b>3. Run a minimal Electron/webview e2e in this repo</b></summary>

- ➕ Closest to real desktop/mobile shell behavior
- ➕ Validates embedded editor boot path end-to-end
- ➖ Slow/flaky compared to pure HTTP tests
- ➖ Requires heavier CI setup; overlaps with downstream CI by design

</details>

**Recommendation:** Keep the current approach: a strict fixture-integrity guard plus an opt-in, clean-skipping live HTTP smoke test. It delivers downstream protection without introducing CI infrastructure requirements or duplicating Electron e2e coverage that belongs in downstream pipelines.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Tests</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>wire-vectors.json</strong> <code>Vendor canonical wire-format vectors fixture</code> <code>+7/-0</code></summary>

<br/>

>Vendor canonical wire-format vectors fixture
>
><pre>
>• Adds a downstream copy of the canonical &#x27;wire-vectors.json&#x27; fixture. The vectors cover basic insert/delete, formatted insert, multiline insert, and attribute reuse scenarios.
></pre>
>
><a href='https://github.com/ether/etherpad-desktop/pull/78/files#diff-84cabdf5d62748e1d3beca82a1d7f543e2fbcaa921a6bad02dcf7e037dee9364'>packages/shell/tests/fixtures/wire-vectors.json</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>smoke.spec.ts</strong> <code>Add optional live Etherpad HTTP roundtrip smoke test</code> <code>+86/-0</code></summary>

<br/>

>Add optional live Etherpad HTTP roundtrip smoke test
>
><pre>
>• Adds a headless-light smoke test that, when configured, creates a pad via the HTTP API, fetches &#x27;/p/&lt;pad&gt;&#x27; (webview URL) and verifies &#x27;getText&#x27;. The test skips cleanly unless a reachable server and &#x27;ETHERPAD_SMOKE_APIKEY&#x27; are present.
></pre>
>
><a href='https://github.com/ether/etherpad-desktop/pull/78/files#diff-ea2af4b52533ee59dbde013675a64c3009f1744f6f198d88b195a09654f95c24'>packages/shell/tests/wire/smoke.spec.ts</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>vectors.spec.ts</strong> <code>Add fixture-integrity guard for wire vectors contract</code> <code>+88/-0</code></summary>

<br/>

>Add fixture-integrity guard for wire vectors contract
>
><pre>
>• Adds a Vitest suite that validates the vendored vectors are non-empty, uniquely named, and conform to the expected schema. It asserts canonical &#x27;Z:&#x27; changeset headers, pool shape (&#x27;numToAttrib&#x27; object, non-negative integer &#x27;nextNum&#x27;), and newline-terminated non-empty texts; fixture path is overrideable via &#x27;ETHERPAD_WIRE_VECTORS&#x27;.
></pre>
>
><a href='https://github.com/ether/etherpad-desktop/pull/78/files#diff-cd2f0319fcf49a6c9c6ebb9a97ba6726aab473386825243d06e6662f3bbafb4e'>packages/shell/tests/wire/vectors.spec.ts</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>package.json</strong> <code>Add root scripts for vectors and smoke test entrypoints</code> <code>+2/-0</code></summary>

<br/>

>Add root scripts for vectors and smoke test entrypoints
>
><pre>
>• Introduces &#x27;test:vectors&#x27; and &#x27;test:smoke&#x27; scripts that run targeted Vitest specs in &#x27;@etherpad/shell&#x27;. This makes the downstream wire-compat checks easy to invoke from CI and locally.
></pre>
>
><a href='https://github.com/ether/etherpad-desktop/pull/78/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519'>package.json</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>